### PR TITLE
Re-add Query.bypass_cache to extended

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -270,6 +270,12 @@ components:
       properties:
         message:
           $ref: '#/components/schemas/Message'
+        bypass_cache:
+          type: string
+          example: 'true'
+          description: >-
+            Set to true in order to bypass any possible cached message and try to
+            answer the query over again
       additionalProperties: true
       required:
         - message


### PR DESCRIPTION
The Query class used to have a bypass_cache attribute, but it was accidentally deleted in 0.9.1 -> 0.9.2
Use this flag to bypass potential answer caching