### PR TITLE
Add alternative bypass_cache

### DIFF
--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -75,11 +75,11 @@ paths:
       parameters:
         - name: bypass_cache
           in: query
-          description: Set to true in order to bypass any possible cached result message and try to answer the query over again
-          required: false
-          type: boolean
-          default: false
-          example: true
+          description: >
+            Set to true in order to bypass any possible cached result
+            message and try to answer the query over again
+          schema:
+            type: boolean
       requestBody:
         description: Query information to be submitted
         required: true

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -78,9 +78,9 @@ paths:
           description: >
             Set to true in order to bypass any possible cached result
             message and try to answer the query over again
-          default: false
           schema:
             type: boolean
+            default: false
       requestBody:
         description: Query information to be submitted
         required: true

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -72,6 +72,14 @@ paths:
       summary: Query reasoner via one of several inputs
       description: ''
       operationId: query
+      parameters:
+        - name: bypass_cache
+          in: query
+          description: Set to true in order to bypass any possible cached result message and try to answer the query over again
+          required: false
+          type: boolean
+          default: false
+          example: true
       requestBody:
         description: Query information to be submitted
         required: true

--- a/API/TranslatorReasonersAPI.yaml
+++ b/API/TranslatorReasonersAPI.yaml
@@ -78,6 +78,7 @@ paths:
           description: >
             Set to true in order to bypass any possible cached result
             message and try to answer the query over again
+          default: false
           schema:
             type: boolean
       requestBody:


### PR DESCRIPTION
Instead of having bypass_cache as a Query object attribute, see if it is more palatable as query parameter.
Is it possible to have query parameter alongside a requestBody? I assume so, but I don't know this to work
For the `extended` branch
The assumption is that if a server does not implement this, then there is no caching. If you implement caching, you should do it this way.