### PR TITLE
Add asynchronous interface

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -100,6 +100,97 @@ paths:
               schema:
                 type: string
       x-swagger-router-controller: swagger_server.controllers.query_controller
+  /aquery:
+    post:
+      tags:
+        - query
+      summary: Asynchronously query reasoner via one of several inputs
+      description: ''
+      operationId: aquery
+      requestBody:
+        description: Query information to be submitted
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Query'
+      responses:
+        '202':
+          description: >-
+            Accepted. Poll /aresponse for results.
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: >-
+            Bad request. The request is invalid according to this OpenAPI
+            schema OR a specific identifier is believed to be invalid somehow
+            (not just unrecognized).
+          content:
+            application/json:
+              schema:
+                type: string
+        '500':
+          description: >-
+            Internal server error.
+          content:
+            application/json:
+              schema:
+                type: string
+        '501':
+          description: >-
+            Not implemented.
+          content:
+            application/json:
+              schema:
+                type: string
+      x-swagger-router-controller: swagger_server.controllers.query_controller
+  /aresponse/{query_id}:
+    get:
+      tags:
+        - query
+      summary: Retrieve response to asynchronous query
+      description: ''
+      operationId: aresponse
+      parameters:
+        - in: path
+          name: query_id
+          schema:
+            type: string
+          required: true
+          description: Query id returned from /aquery
+      responses:
+        '200':
+          description: >-
+            OK. There may or may not be results. Note that some of the provided
+            identifiers may not have been recognized.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Query'
+        '404':
+          description: >-
+            Not found. No such query has been submitted.
+          content:
+            application/json:
+              schema:
+                type: string
+        '500':
+          description: >-
+            Internal server error.
+          content:
+            application/json:
+              schema:
+                type: string
+        '501':
+          description: >-
+            Not implemented.
+          content:
+            application/json:
+              schema:
+                type: string
+      x-swagger-router-controller: swagger_server.controllers.query_controller
 components:
   schemas:
     Query:


### PR DESCRIPTION
`/aquery` returns a query_id (string)
`/aresponse/{query_id}` returns a Message