### PR TITLE
Response metadata

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -66,7 +66,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Query'
+              $ref: '#/components/schemas/Request'
       responses:
         '200':
           description: >-
@@ -75,7 +75,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Message'
+                $ref: '#/components/schemas/Response'
         '400':
           description: >-
             Bad request. The request is invalid according to this OpenAPI
@@ -102,16 +102,22 @@ paths:
       x-swagger-router-controller: swagger_server.controllers.query_controller
 components:
   schemas:
-    Query:
+    Request:
       x-body-name: request_body
       type: object
       properties:
-        message:
-          $ref: '#/components/schemas/Message'
-      additionalProperties: true
+        data:
+          $ref: '#/components/schemas/Data'
       required:
-        - message
-    Message:
+        - data
+    Response:
+      type: object
+      properties:
+        data:
+          $ref: '#/components/schemas/Data'
+      required:
+        - data
+    Data:
       type: object
       properties:
         results:
@@ -133,7 +139,7 @@ components:
             referenced in any of the possible answers to the query OR
             connection information for a remote knowledge graph
           $ref: '#/components/schemas/KnowledgeGraph'
-      additionalProperties: true
+      additionalProperties: false
     Result:
       type: object
       description: One of potentially several results or answers for a query

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -115,6 +115,10 @@ components:
       properties:
         data:
           $ref: '#/components/schemas/Data'
+        logs:
+          type: array
+          items:
+            $ref: '#/components/schema/LogEntry'
       required:
         - data
     Data:
@@ -140,6 +144,30 @@ components:
             connection information for a remote knowledge graph
           $ref: '#/components/schemas/KnowledgeGraph'
       additionalProperties: false
+    LogEntry:
+      type: object
+      properties:
+        timestamp:
+          type: string
+          format: date-time
+          description: Timestamp in ISO 8601 format
+          example: '2020-09-03T18:13:49+00:00'
+        level:
+          type: string
+          description: Logging level
+          enum:
+            - ERROR
+            - WARNING
+            - INFO
+            - DEBUG
+        code:
+          type: string
+          description: >-
+            One of a standardized set of short codes
+            e.g. QueryNotTraversable, KPNotAvailable, KPResponseMalformed
+        message:
+          type: string
+          description: A human-readable log message
     Result:
       type: object
       description: One of potentially several results or answers for a query


### PR DESCRIPTION
This slightly reframes how we talk about requests and responses by replacing the Query and Message structures with Request, Response, and Data. It also adds structured `logs` as metadata to the Response.

Formerly, requests to /query were Query objects, each of which contained a Message. We basically rename these, referring to them as Request and Data respectively, where Data is identical to Message except that extra fields beyond `query_graph`, `knowledge_graph`, and `results` are not allowed.

Formerly, responses from /query were Message objects. Now they are Response objects, each of which contains Data. Then a list of LogEntries is added to serve as response "metadata". Each LogEntry includes fields `timestamp`, `level`, `message` (not to be confused with the old usage), and `code` (which serves as a standardized label e.g. QueryNotTraversable, KPNotAvailable, or KPResponseMalformed).