### PR TITLE
Re-synchronize the extended schema with new core

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -139,7 +139,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Message'
+                $ref: '#/components/schemas/Response'
         '404':
           description: Message_id not found
       x-swagger-router-controller: swagger_server.controllers.message_controller

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -30,12 +30,12 @@ tags:
     description: Request stored messages and feedback for messages
     externalDocs:
       description: Documentation for the reasoner message function
-      url: 'https://reasonerhost.ncats.io/overview.html#message'
+      url: https://reasonerhost.ncats.io/overview.html#message
   - name: result
     description: Request stored results and feedback for results
     externalDocs:
       description: Documentation for the reasoner result function
-      url: 'http://reasonerhost.ncats.io/overview.html#result'
+      url: http://reasonerhost.ncats.io/overview.html#result
 paths:
   /predicates:
     get:
@@ -201,17 +201,17 @@ components:
             $ref: '#/components/schemas/LogEntry'
         message_id:
           type: string
-          example: 'https://arax.ncats.io/api/rtx/v1/message/123'
+          example: https://arax.ncats.io/api/rtx/v1/message/123
           description: URI for this message
         reasoner_id:
           type: string
           example: reasoner
           description: >-
-            Identifier string of the reasoner that provided this message (one of
-            RTX, Robokop, Indigo, Integrator, etc.)
+            Identifier string of the reasoner that provided this message
+            (one of ARAX, Robokop, etc.)
         tool_version:
           type: string
-          example: RTX 0.5.0
+          example: ARAX 0.6.1
           description: Version label of the tool that generated this message
         schema_version:
           type: string
@@ -220,13 +220,15 @@ components:
         datetime:
           type: string
           example: '2018-01-09 12:34:45'
-          description: Datetime string for the time that this message was generated
+          description:  >-
+            Datetime string for the time that this message was generated
         table_column_names:
           type: array
           example:
             - chemical_substance.name
             - chemical_substance.id
-          description: List of column names that corresponds to the row_data for each result
+          description: >-
+            List of column names that corresponds to the row_data for each result
           items:
             type: string
         original_question:
@@ -238,16 +240,15 @@ components:
           example: Which proteins are affected by sickle cell anemia?
           description: >-
             A precise restatement of the question, as understood by the
-            Translator, for which the answer applies. The user should verify that
-            the restated question matches the intent of their original question
-            (it might not).
+            Translator, for which the answer applies. The user should verify
+            that the restated question matches the intent of their original
+            question (it might not).
         query_type_id:
           type: string
           example: Q2
           description: >-
             The query type id if one is known for the query/message (as defined in
-            https://docs.google.com/spreadsheets/d/18zW81wteUfOn3rFRVG0z8mW-ecNhdsfD_6s73ETJnUw/edit#gid=1742835901
-            )
+            a shared manner)
         terms:
           type: object
           description: Dict of terms needed by the specific query type
@@ -270,7 +271,7 @@ components:
           additionalProperties: true
         query_options:
           type: object
-          example: 
+          example:
             coalesce: true
             threshold: 0.9
           description: >-
@@ -351,15 +352,16 @@ components:
               $ref: '#/components/schemas/EdgeBinding'
         id:
           type: string
-          example: 'https://rtx.ncats.io/api/rtx/v1/result/234'
+          example: https://arax.ncats.io/api/rtx/v1/result/234
           description: URI for this message
         description:
           type: string
           example: >-
-            The genetic condition sickle cell anemia may provide protection from
-            cerebral malaria via genetic alterations of proteins HBB (P68871) and
-            HMOX1 (P09601).
-          description: A free text description of this result answer from the reasoner
+            The genetic condition sickle cell anemia may provide protection
+            from cerebral malaria via genetic alterations of proteins HBB
+            (P68871) and HMOX1 (P09601).
+          description: >-
+            A free text description of this result answer from the reasoner
         essence:
           type: string
           example: ibuprofen
@@ -374,7 +376,7 @@ components:
           type: array
           example:
             - ibuprofen
-            - 'CHEMBL:CHEMBL521'
+            - CHEMBL:CHEMBL521
           description: >-
             An arbitrary list of values that captures the essence of the result
             that can be turned into a tabular result across all answers (each
@@ -401,8 +403,8 @@ components:
           format: float
           example: 0.9234
           description: >-
-            Confidence metric for this result, a value between (inclusive) 0.0 (no
-            confidence) and 1.0 (highest confidence)
+            Confidence metric for this result, a value between (inclusive)
+             0.0 (no confidence) and 1.0 (highest confidence)
         result_type:
           type: string
           example: individual query answer
@@ -421,8 +423,8 @@ components:
           format: float
           example: 0.95
           description: >-
-            A score that denotes the similarity of this result to other members of
-            the result_group
+            A score that denotes the similarity of this result to other members
+            of the result_group
         reasoner_id:
           type: string
           example: RTX

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -26,11 +26,6 @@ tags:
       url: http://reasonerhost.ncats.io/overview.html#query
   - name: translator
   - name: reasoner
-  - name: feedback
-    description: Get or submit feedback regarding a query result
-    externalDocs:
-      description: Documentation for the reasoner feedback function
-      url: 'http://reasonerhost.ncats.io/overview.html#feedback'
   - name: message
     description: Request stored messages and feedback for messages
     externalDocs:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -142,7 +142,8 @@ paths:
                 $ref: '#/components/schemas/Response'
         '404':
           description: Message_id not found
-      x-swagger-router-controller: swagger_server.controllers.message_controller
+      x-swagger-router-controller: \
+        swagger_server.controllers.message_controller
 components:
   schemas:
     Query:
@@ -220,7 +221,7 @@ components:
         datetime:
           type: string
           example: '2018-01-09 12:34:45'
-          description:  >-
+          description: >-
             Datetime string for the time that this message was generated
         table_column_names:
           type: array
@@ -228,7 +229,8 @@ components:
             - chemical_substance.name
             - chemical_substance.id
           description: >-
-            List of column names that corresponds to the row_data for each result
+            List of column names that corresponds to the row_data for
+            each result
           items:
             type: string
         original_question:
@@ -247,8 +249,8 @@ components:
           type: string
           example: Q2
           description: >-
-            The query type id if one is known for the query/message (as defined in
-            a shared manner)
+            The query type id if one is known for the query/message
+            (as defined in a shared manner)
         terms:
           type: object
           description: Dict of terms needed by the specific query type

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -26,6 +26,21 @@ tags:
       url: http://reasonerhost.ncats.io/overview.html#query
   - name: translator
   - name: reasoner
+  - name: feedback
+    description: Get or submit feedback regarding a query result
+    externalDocs:
+      description: Documentation for the reasoner feedback function
+      url: 'http://reasonerhost.ncats.io/overview.html#feedback'
+  - name: message
+    description: Request stored messages and feedback for messages
+    externalDocs:
+      description: Documentation for the reasoner message function
+      url: 'https://reasonerhost.ncats.io/overview.html#message'
+  - name: result
+    description: Request stored results and feedback for results
+    externalDocs:
+      description: Documentation for the reasoner result function
+      url: 'http://reasonerhost.ncats.io/overview.html#result'
 paths:
   /predicates:
     get:
@@ -60,6 +75,15 @@ paths:
       summary: Query reasoner via one of several inputs
       description: ''
       operationId: query
+      parameters:
+        - name: bypass_cache
+          in: query
+          description: >
+            Set to true in order to bypass any possible cached result
+            message and try to answer the query over again
+          schema:
+            type: boolean
+            default: false
       requestBody:
         description: Query information to be submitted
         required: true
@@ -100,6 +124,30 @@ paths:
               schema:
                 type: string
       x-swagger-router-controller: swagger_server.controllers.query_controller
+  '/message/{message_id}':
+    get:
+      tags:
+        - message
+      summary: Request stored messages and results from reasoner
+      description: ''
+      operationId: get_message
+      parameters:
+        - in: path
+          name: message_id
+          description: Integer identifier of the message to return
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Message'
+        '404':
+          description: Message_id not found
+      x-swagger-router-controller: swagger_server.controllers.message_controller
 components:
   schemas:
     Query:
@@ -156,8 +204,86 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LogEntry'
+        message_id:
+          type: string
+          example: 'https://arax.ncats.io/api/rtx/v1/message/123'
+          description: URI for this message
+        reasoner_id:
+          type: string
+          example: reasoner
+          description: >-
+            Identifier string of the reasoner that provided this message (one of
+            RTX, Robokop, Indigo, Integrator, etc.)
+        tool_version:
+          type: string
+          example: RTX 0.5.0
+          description: Version label of the tool that generated this message
+        schema_version:
+          type: string
+          example: 0.9.0
+          description: Version label of this JSON-LD schema
+        datetime:
+          type: string
+          example: '2018-01-09 12:34:45'
+          description: Datetime string for the time that this message was generated
+        table_column_names:
+          type: array
+          example:
+            - chemical_substance.name
+            - chemical_substance.id
+          description: List of column names that corresponds to the row_data for each result
+          items:
+            type: string
+        original_question:
+          type: string
+          example: what proteins are affected by sickle cell anemia
+          description: The original question text typed in by the user
+        restated_question:
+          type: string
+          example: Which proteins are affected by sickle cell anemia?
+          description: >-
+            A precise restatement of the question, as understood by the
+            Translator, for which the answer applies. The user should verify that
+            the restated question matches the intent of their original question
+            (it might not).
+        query_type_id:
+          type: string
+          example: Q2
+          description: >-
+            The query type id if one is known for the query/message (as defined in
+            https://docs.google.com/spreadsheets/d/18zW81wteUfOn3rFRVG0z8mW-ecNhdsfD_6s73ETJnUw/edit#gid=1742835901
+            )
+        terms:
+          type: object
+          description: Dict of terms needed by the specific query type
+          properties:
+            disease:
+              type: string
+              example: malaria
+            protein:
+              type: string
+              example: P12345
+            anatomical_entity:
+              type: string
+              example: liver
+            chemical_substance:
+              type: string
+              example: ibuprofen
+            metabolite:
+              type: string
+              example: ibuprofen
+          additionalProperties: true
+        query_options:
+          type: object
+          example: 
+            coalesce: true
+            threshold: 0.9
+          description: >-
+            Dict of options that can be sent with the query. Options are tool
+            specific and not stipulated here
       required:
         - message
+      additionalProperties: true
     Message:
       type: object
       properties:
@@ -228,6 +354,86 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/EdgeBinding'
+        id:
+          type: string
+          example: 'https://rtx.ncats.io/api/rtx/v1/result/234'
+          description: URI for this message
+        description:
+          type: string
+          example: >-
+            The genetic condition sickle cell anemia may provide protection from
+            cerebral malaria via genetic alterations of proteins HBB (P68871) and
+            HMOX1 (P09601).
+          description: A free text description of this result answer from the reasoner
+        essence:
+          type: string
+          example: ibuprofen
+          description: >-
+            A single string that is the terse essence of the result (useful for
+            simple answers)
+        essence_type:
+          type: string
+          example: drug
+          description: A Translator bioentity type of the essence
+        row_data:
+          type: array
+          example:
+            - ibuprofen
+            - 'CHEMBL:CHEMBL521'
+          description: >-
+            An arbitrary list of values that captures the essence of the result
+            that can be turned into a tabular result across all answers (each
+            result is a row) for a user that wants tabular output
+          items:
+            type: string
+        score:
+          type: number
+          format: float
+          example: 163.233
+          description: Any type of score associated with this result
+        score_name:
+          type: string
+          example: Jaccard distance
+          description: Name for the score
+        score_direction:
+          type: string
+          example: lower_is_better
+          description: >-
+            Sorting indicator for the score: one of higher_is_better or
+            lower_is_better
+        confidence:
+          type: number
+          format: float
+          example: 0.9234
+          description: >-
+            Confidence metric for this result, a value between (inclusive) 0.0 (no
+            confidence) and 1.0 (highest confidence)
+        result_type:
+          type: string
+          example: individual query answer
+          description: >-
+            One of several possible result types: 'individual query answer',
+            'neighborhood graph', 'type summary graph'
+        result_group:
+          type: integer
+          example: 1
+          description: >-
+            An integer group number for results for use in cases where several
+            results should be grouped together. Also useful to control sorting
+            ascending.
+        result_group_similarity_score:
+          type: number
+          format: float
+          example: 0.95
+          description: >-
+            A score that denotes the similarity of this result to other members of
+            the result_group
+        reasoner_id:
+          type: string
+          example: RTX
+          description: >-
+            Identifier string of the reasoner that provided this result (e.g.,
+            RTX, Robokop, Indigo, Integrator)
       required:
         - node_bindings
         - edge_bindings


### PR DESCRIPTION
Many of the properties of the 0.9.2 extended schema are integrated with the 1.0.0-beta extended schema after realignment to the new redesigned Core schema
All the feedback components were left behind due to lack of interest. they can be resurrected/redesigned if wanted
Many properties were dropped since there is no place to put them in the new schema, but the data they contain could go in Attributes