### PR TITLE
(Q)Edge.relation should be an ontology CURIE

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -410,8 +410,8 @@ components:
         predicate:
           $ref: '#/components/schemas/BiolinkRelation'
         relation:
-          type: string
-          example: upregulates
+          $ref: '#/components/schemas/CURIE'
+          example: RO:0002447
           description: Lower-level relationship type of this edge
         subject:
           $ref: '#/components/schemas/CURIE'

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -332,8 +332,8 @@ components:
               items:
                 $ref: '#/components/schemas/BiolinkRelation'
         relation:
-          type: string
-          example: upregulates
+          $ref: '#/components/schemas/CURIE'
+          example: RO:0002447
           description: Lower-level relationship type of this edge
         subject:
           type: string


### PR DESCRIPTION
If TRAPI and the Biolink Model are to remain closely aligned at the fundamental semantic level, then the `Edge.relation` property of a KnowledgeGraph, and probably the QEdge of the QueryGraph, absolutely need to have a value of CURIE dereferencing a formal external 3rd party ontology class definition. 

I believe this to be a release 1.0 'bug' in the TRAPI schema.