### PR TITLE
Add provenance holder for Edge

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -428,6 +428,10 @@ components:
           description: A list of additional attributes for this edge
           items:
             $ref: '#/components/schemas/Attribute'
+        provenance:
+          type: object
+          description: >-
+            A free-form object for holding provenance information.
       additionalProperties: false
       required:
         - subject


### PR DESCRIPTION
This information does not belong in attributes, but additionalProperties are explicitly disallowed.

I expect this to be more fully specified in future releases, but for now, I need somewhere to put provenance information.