### PR TITLE
Remove old swagger 2.0 cruft

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -99,7 +99,6 @@ paths:
             application/json:
               schema:
                 type: string
-      x-swagger-router-controller: swagger_server.controllers.query_controller
 components:
   schemas:
     Query:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   description: OpenAPI for NCATS Biomedical Translator Reasoners
-  version: 1.0.0
+  version: 1.0.1
   title: OpenAPI for NCATS Biomedical Translator Reasoners
   contact:
     email: edeutsch@systemsbiology.org


### PR DESCRIPTION
Remove old swagger 2.0 cruft. I assume that removing this doesn't really break or change anything. This is for the /query endpoint. It is already removed for the /predicates endpoint.

