### PR TITLE
Remove 'oneOf' throughout

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -99,7 +99,6 @@ paths:
             application/json:
               schema:
                 type: string
-      x-swagger-router-controller: swagger_server.controllers.query_controller
 components:
   schemas:
     Query:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -367,7 +367,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CURIE'
-            example: ['OMIM:603903']
+          example: ['OMIM:603903']
           description: CURIE identifier for this node
           nullable: true
         category:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -367,7 +367,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CURIE'
-          example: ['OMIM:603903']
+          example: [OMIM:603903]
           description: CURIE identifier for this node
           nullable: true
         category:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -367,7 +367,7 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CURIE'
-            example: OMIM:603903
+            example: ['OMIM:603903']
           description: CURIE identifier for this node
           nullable: true
         category:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   description: OpenAPI for NCATS Biomedical Translator Reasoners
-  version: 1.0.1
+  version: 1.1.0
   title: OpenAPI for NCATS Biomedical Translator Reasoners
   contact:
     email: edeutsch@systemsbiology.org
@@ -363,14 +363,14 @@ components:
         query. If a CURIE is not specified, any nodes matching the category
         of the QNode will be returned in the Results.
       properties:
-        id:
+        ids:
           type: array
           items:
             $ref: '#/components/schemas/CURIE'
           example: [OMIM:603903]
           description: CURIE identifier for this node
           nullable: true
-        category:
+        categories:
           type: array
           items:
             $ref: '#/components/schemas/BiolinkEntity'
@@ -401,7 +401,7 @@ components:
         an exact match to the given QEdge predicate or relation term ('class'),
         or to a term which is a subclass of the QEdge specified term.
       properties:
-        predicate:
+        predicates:
           type: array
           items:
             $ref: '#/components/schemas/BiolinkPredicate'
@@ -446,7 +446,7 @@ components:
           example: Haptoglobin
           description: Formal name of the entity
           nullable: true
-        category:
+        categories:
           type: array
           items:
             $ref: '#/components/schemas/BiolinkEntity'

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -364,20 +364,16 @@ components:
         of the QNode will be returned in the Results.
       properties:
         id:
-          oneOf:
-            - $ref: '#/components/schemas/CURIE'
-            - type: array
-              items:
-                $ref: '#/components/schemas/CURIE'
-          example: OMIM:603903
+          type: array
+          items:
+            $ref: '#/components/schemas/CURIE'
+            example: OMIM:603903
           description: CURIE identifier for this node
           nullable: true
         category:
-          oneOf:
-            - $ref: '#/components/schemas/BiolinkEntity'
-            - type: array
-              items:
-                $ref: '#/components/schemas/BiolinkEntity'
+          type: array
+          items:
+            $ref: '#/components/schemas/BiolinkEntity'
           nullable: true
         is_set:
           type: boolean
@@ -406,11 +402,9 @@ components:
         or to a term which is a subclass of the QEdge specified term.
       properties:
         predicate:
-          oneOf:
-            - $ref: '#/components/schemas/BiolinkPredicate'
-            - type: array
-              items:
-                $ref: '#/components/schemas/BiolinkPredicate'
+          type: array
+          items:
+            $ref: '#/components/schemas/BiolinkPredicate'
           nullable: true
         relation:
           type: string
@@ -453,11 +447,9 @@ components:
           description: Formal name of the entity
           nullable: true
         category:
-          oneOf:
-            - $ref: '#/components/schemas/BiolinkEntity'
-            - type: array
-              items:
-                $ref: '#/components/schemas/BiolinkEntity'
+          type: array
+          items:
+            $ref: '#/components/schemas/BiolinkEntity'
           nullable: true
         attributes:
           type: array

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   description: OpenAPI for NCATS Biomedical Translator Reasoners
-  version: 1.0.0
+  version: 1.0.1
   title: OpenAPI for NCATS Biomedical Translator Reasoners
   contact:
     email: edeutsch@systemsbiology.org


### PR DESCRIPTION
This addresses a pain point that was discussed a couple weeks ago on the TRAPI working group call: that many users are having to deal with a bug in the `openapi-generator` tool wherein the the Python Flask server generator cannot handle union types (see https://github.com/OpenAPITools/openapi-generator/issues/5187.)

Here we remove the 'oneOf a Thing or an array of Thing' that was causing this issue. Instead, the type of these properties is now an 'array of Thing,' wherein objects with only a single `id,` `category,` etc. can simply be one-element arrays of Thing. Below is an example of the diff for models generated with `openapi-generator`

Using current `master` yaml with the command
`openapi-generator generate -i ReasonerAPI-master-b3ed382.yaml -g python-flask --package-name test_master -o tmp/test_master`:

```
...
from typing import List, Dict  # noqa: F401

from test_master.models.base_model_ import Model
from test_master.models.one_ofstringarray import OneOfstringarray
from test_master import util

from test_master.models.one_ofstringarray import OneOfstringarray  # noqa: E501

class QNode(Model):
    def __init__(self, id=None, category=None, is_set=False):  # noqa: E501
        """QNode - a model defined in OpenAPI

        :param id: The id of this QNode.  # noqa: E501
        :type id: OneOfstringarray
        :param category: The category of this QNode.  # noqa: E501
        :type category: OneOfstringarray
        :param is_set: The is_set of this QNode.  # noqa: E501
        :type is_set: bool
        """
        self.openapi_types = {
            'id': OneOfstringarray,
            'category': OneOfstringarray,
            'is_set': bool
        }

        self.attribute_map = {
            'id': 'id',
            'category': 'category',
            'is_set': 'is_set'
        }

        self._id = id
        self._category = category
        self._is_set = is_set
...
```

versus the changes in this PR's yaml generated with the command
`openapi-generator generate -i ReasonerAPI-no-oneof.yaml -g python-flask --package-name test_no_oneof -o tmp/no_oneof`
```
...
from typing import List, Dict  # noqa: F401

from test_no_oneof.models.base_model_ import Model
from test_no_oneof import util


class QNode(Model):
    def __init__(self, id=None, category=None, is_set=False):  # noqa: E501
        """QNode - a model defined in OpenAPI

        :param id: The id of this QNode.  # noqa: E501
        :type id: List[str]
        :param category: The category of this QNode.  # noqa: E501
        :type category: List[str]
        :param is_set: The is_set of this QNode.  # noqa: E501
        :type is_set: bool
        """
        self.openapi_types = {
            'id': List[str],
            'category': List[str],
            'is_set': bool
        }

        self.attribute_map = {
            'id': 'id',
            'category': 'category',
            'is_set': 'is_set'
        }

        self._id = id
        self._category = category
        self._is_set = is_set
...
```
Users of this tool will recognize that the imported `OneOfstringarray` classes in the `master` example are not generated and must be accommodated manually by the developer.

My take: I don't feel too strongly about this, but it was recognized as a pain point for multiple teams. On one hand, we shouldn't make design accommodations to a bug in an external tool. On the other, lots of teams use said tool and there is little movement to get this fixed in the tool itself. Further, it does seem a little redundant to have 'str or array of str' as the specified type when it's presumably simpler for developers to always expect an array, even if it's only one element. Personally, in our code, I have chosen to always deserialize this to an 'array of thing' to make downstream code less complex.