### PR TITLE
Alter location of statement of TRAPI support

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.1
 info:
   description: OpenAPI for NCATS Biomedical Translator Reasoners
-  version: 1.1.0
+  version: INSERT-VERSION-OF-YOUR-SERVICE-HERE
   title: OpenAPI for NCATS Biomedical Translator Reasoners
   contact:
     email: edeutsch@systemsbiology.org
@@ -9,6 +9,8 @@ info:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
   termsOfService: INSERT-URL-HERE
+  x-trapi:
+    version: 1.1.0
 externalDocs:
   description: >-
     Documentation for the NCATS Biomedical Translator Reasoners web services


### PR DESCRIPTION
I think this is the proposal that was on the table? Use x-trapi extension to signal which version of TRAPI is supported by a service. Service is free to use the top-level version to specify the version of their service.