### PR TITLE
add biolink-model version to x-translator

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -13,6 +13,7 @@ info:
     component: INSERT-EITHER-ARA-OR-KP-OR-ARS-OR-Utility-HERE
     team:
       - INSERT-ONE-TRANSLATOR-TEAM-NAME-PER-ELEMENT-HERE
+    biolink-version: INSERT-BIOLINK-MODEL-VERSION-HERE
     externalDocs:
       description: >-
         The values for component and team are restricted according to this


### PR DESCRIPTION
Conforms to [biolink-version in SmartAPI](https://github.com/NCATSTranslator/translator_extensions/blob/62755f92c82d6aafa2ae55c394434640ebb9a0dd/x-translator/smartapi_x-translator_schema.json)