### PR TITLE
Make value_type_id nullable as intended

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -21,7 +21,7 @@ info:
       url: https://github.com/NCATSTranslator/translator_extensions/blob/\
         production/x-translator/
   x-trapi:
-    version: 1.1.0
+    version: 1.1.1
     externalDocs:
       description: >-
         The values for version are restricted according to the regex in
@@ -565,7 +565,8 @@ components:
             Value of the attribute. May be any data type, including a list.
           example: 0.000153
         value_type_id:
-          $ref: '#/components/schemas/CURIE'
+          allOf:
+            - $ref: '#/components/schemas/CURIE'
           description: >-
             CURIE describing the semantic type of an  attribute's value. Use
             a Biolink class if possible, otherwise a term from an external
@@ -573,6 +574,7 @@ components:
             descriptive phrase here and submit the new type for consideration
             by the appropriate authority.
           example: EDAM:data_1187
+          nullable: true
         attribute_source:
           type: string
           description: >-


### PR DESCRIPTION
The released schema does not explicitly allow value_type_id to be nullable although this was intended by not making is required.