### PR TITLE
upgrade confidence and score from extended

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -319,24 +319,10 @@ components:
           type: number
           format: float
           example: 163.233
-          description: Any numerical score associated with this result
-        score_name:
-          type: string
-          example: Jaccard distance
-          description: Name for the score
-        score_direction:
-          type: string
-          example: lower_is_better
           description: >-
-            Sorting indicator for the score: one of higher_is_better or
-            lower_is_better
-        confidence:
-          type: number
-          format: float
-          example: 0.9234
-          description: >-
-            Confidence metric for this result, a value between (inclusive)
-             0.0 (no confidence) and 1.0 (highest confidence)
+            A numerical score associated with this result indicating the
+            relevance or confidence of this result relative to others in the
+            returned set. No range is prescribed. Higher MUST be better.
       additionalProperties: true
       required:
         - node_bindings

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -21,7 +21,7 @@ info:
       url: https://github.com/NCATSTranslator/translator_extensions/blob/\
         production/x-translator/
   x-trapi:
-    version: 1.1.1
+    version: 1.1.2
     externalDocs:
       description: >-
         The values for version are restricted according to the regex in
@@ -322,7 +322,7 @@ components:
           description: >-
             A numerical score associated with this result indicating the
             relevance or confidence of this result relative to others in the
-            returned set. No range is prescribed. Higher MUST be better.
+            returned set. Higher MUST be better.
       additionalProperties: true
       required:
         - node_bindings

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -315,6 +315,28 @@ components:
             type: array
             items:
               $ref: '#/components/schemas/EdgeBinding'
+        score:
+          type: number
+          format: float
+          example: 163.233
+          description: Any numerical score associated with this result
+        score_name:
+          type: string
+          example: Jaccard distance
+          description: Name for the score
+        score_direction:
+          type: string
+          example: lower_is_better
+          description: >-
+            Sorting indicator for the score: one of higher_is_better or
+            lower_is_better
+        confidence:
+          type: number
+          format: float
+          example: 0.9234
+          description: >-
+            Confidence metric for this result, a value between (inclusive)
+             0.0 (no confidence) and 1.0 (highest confidence)
       additionalProperties: true
       required:
         - node_bindings


### PR DESCRIPTION
These already exist in the extended schema. They are already used by ARAX and the ARAX viewer as shown for a long time.
This is a proposal to make them a standard part of the core (and become recommended for all results?)
Refinement or alternatives are welcome.
Addresses #246