### PR TITLE
Batch, Op&Wf: message -> messages[ ]

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -209,7 +209,7 @@ components:
           nullable: true
       additionalProperties: true
       required:
-        - message
+        - messages
     Message:
       description: >-
         The message object holds the main content of a Query or a Response in

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -151,8 +151,11 @@ components:
       x-body-name: request_body
       type: object
       properties:
-        message:
-          $ref: '#/components/schemas/Message'
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+          minItems: 1
           description: >-
             The query Message is a serialization of the user request. Content
             of the Message object depends on the intended TRAPI operation. For
@@ -166,7 +169,7 @@ components:
           nullable: true
       additionalProperties: true
       required:
-        - message
+        - messages
     Response:
       type: object
       description: >-
@@ -177,11 +180,14 @@ components:
         The status, description, and logs properties provide additional details
         about the response.
       properties:
-        message:
+        messages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Message'
+          minItems: 1
           description: >-
             Contains the knowledge of the response (query graph, knowledge
             graph, and results).
-          $ref: '#/components/schemas/Message'
         status:
           description: >-
             One of a standardized set of short codes,


### PR DESCRIPTION
TRAPI 1.1 already supports batching lite via ids[ ]
But more extensive batching seems necessary in 1.2
Presumably at its simplest this is just switching message to messages[ ]
Op&Wf group also wants multiple messages[ ] for merge and diff operations
Seems simple
But there are huge implications for existing code that is designed to accept and emit a single message.
Other options that preserve some backwards compatibility for single-message communication is possible.
What shall we do?