### PR TITLE
Remove 'relation' in MetaEdge?

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -786,13 +786,6 @@ components:
           description: >-
             Object node category of this relationship edge.
           example: biolink:Protein
-        relations:
-          type: array
-          description: >-
-            Low-level relations from the underlying source.
-          items:
-            type: string
-          example: [inhibits, activates]
       required:
         - subject
         - predicate


### PR DESCRIPTION
We scrubbed 'relation' from other parts of the schema. Scrub it out here, too?