### PR TITLE
Pin workflow schema version to 1.0.0

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -195,7 +195,7 @@ components:
           nullable: true
         workflow:
           description: List of workflow steps to be executed.
-          $ref: http://standards.ncats.io/workflow.json
+          $ref: http://standards.ncats.io/workflow/1.0.0/schema
       additionalProperties: true
       required:
         - message
@@ -234,7 +234,7 @@ components:
           nullable: true
         workflow:
           description: List of workflow steps to be executed.
-          $ref: http://standards.ncats.io/workflow.json
+          $ref: http://standards.ncats.io/workflow/1.0.0/schema
       additionalProperties: true
       required:
         - callback
@@ -275,7 +275,7 @@ components:
           nullable: true
         workflow:
           description: List of workflow steps that were executed.
-          $ref: http://standards.ncats.io/workflow.json
+          $ref: http://standards.ncats.io/workflow/1.0.0/schema
       additionalProperties: true
       required:
         - message


### PR DESCRIPTION
The O&W working group decided that it's fine for the workflow and TRAPI schema versions to be decoupled, but we should pin each TRAPI version to a specific workflow version. 