### PR TITLE
Add a submitter property

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -21,7 +21,7 @@ info:
       url: https://github.com/NCATSTranslator/translator_extensions/blob/\
         production/x-translator/
   x-trapi:
-    version: 1.2.0
+    version: 1.2.1
     asyncquery: REPLACE-WITH-true-IF-/asyncquery-IS-IMPLEMENTED-ELSE-false
     operations:
       - LIST-ALL-SUPPORTED-OPERATION-IDS-HERE-OR-REMOVE-THIS-SECTION

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -198,6 +198,13 @@ components:
           allOf:
             - $ref: http://standards.ncats.io/workflow/1.0.0/schema
           nullable: true
+        submitter:
+          type: string
+          description: >-
+            Any string for self-identifying the submitter of a query. The
+            purpose of this optional field is to aid in the tracking of
+            the source of queries for development and issue resolution.
+          nullable: true
       additionalProperties: true
       required:
         - message
@@ -238,6 +245,13 @@ components:
           description: List of workflow steps to be executed.
           allOf:
             - $ref: http://standards.ncats.io/workflow/1.0.0/schema
+          nullable: true
+        submitter:
+          type: string
+          description: >-
+            Any string for self-identifying the submitter of a query. The
+            purpose of this optional field is to aid in the tracking of
+            the source of queries for development and issue resolution.
           nullable: true
       additionalProperties: true
       required:


### PR DESCRIPTION
There was discussion about interest in having an optional slot for query submitters to self-identify themselves to aid in Translator development and issue resolution. It is optional. If this seems useful, please approve or comment. If there is no interest in this, I can withdraw.