### PR TITLE
Propose QEdge.excluded_predicates

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -594,12 +594,6 @@ components:
         an exact match to the given QEdge predicate term,
         or to a term that is a descendant of the QEdge predicate term.
       properties:
-        predicates:
-          type: array
-          items:
-            $ref: '#/components/schemas/BiolinkPredicate'
-          minItems: 1
-          nullable: true
         subject:
           type: string
           example: https://omim.org/entry/603903
@@ -614,6 +608,28 @@ components:
             Corresponds to the map key identifier of the
             object concept node anchoring the query filter
             pattern for the query relationship edge.
+        predicates:
+          type: array
+          items:
+            $ref: '#/components/schemas/BiolinkPredicate'
+          minItems: 1
+          nullable: true
+        excluded_predicates:
+          type: array
+          items:
+            $ref: '#/components/schemas/BiolinkPredicate'
+          minItems: 1
+          nullable: true
+          description: >-
+            An array of predicates that should be excluded from any results.
+            For example, a client may want to explore all possible relationships
+            between a drug and a disease but is not interested in
+            contraindications. In this case, the client would specify the
+            predicates field with ['biolink:related_to'] (or leave the
+            predicates field unspecified) and would specify the
+            excluded_predicates field with ['biolink:contraindicated_for'].
+            In this case, the server must exclude any results that have the
+            contraindicated_for predicate.
         constraints:
           type: array
           description: >-

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -622,9 +622,9 @@ components:
           nullable: true
           description: >-
             An array of predicates that should be excluded from any results.
-            For example, a client may want to explore all possible relationships
-            between a drug and a disease but is not interested in
-            contraindications. In this case, the client would specify the
+            For example, a client may want to explore all possible
+            relationships between a drug and a disease but is not interested
+            in contraindications. In this case, the client would specify the
             predicates field with ['biolink:related_to'] (or leave the
             predicates field unspecified) and would specify the
             excluded_predicates field with ['biolink:contraindicated_for'].


### PR DESCRIPTION
This is a competing proposal to implement a restriction on the predicates that can be included in a result. The other proposal can be found here: https://github.com/NCATSTranslator/ReasonerAPI/pull/306

Here we introduce the `excluded_predicates` property on the `QEdge` object as an array of predicates that the server must exclude from any results. The naming of the property is certainly flexible, and we can change it if we want to make it shorter.

Note that ordering of the QEdge property list has changed such that the required `subject` and `object` fields appear before any optional properties. I think this is generally accepted OpenAPI style, and it makes auto-generated docs a little more friendly.