### PR TITLE
Add Attributes to NodeBindings

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -436,6 +436,16 @@ components:
             Node within the Knowledge Graph. Instances of NodeBinding may
             include extra annotation (such annotation is not yet fully
             standardized).
+        attributes:
+          type: array
+          description: >-
+            A list of attributes providing further information about the
+            nodee binding. This is not intended for capturing node attributes
+            and should only be used for properties that vary from result to
+            result.
+          items:
+            $ref: '#/components/schemas/Attribute'
+          nullable: true
       additionalProperties: true
       required:
         - id

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -440,7 +440,7 @@ components:
           type: array
           description: >-
             A list of attributes providing further information about the
-            nodee binding. This is not intended for capturing node attributes
+            node binding. This is not intended for capturing node attributes
             and should only be used for properties that vary from result to
             result.
           items:


### PR DESCRIPTION
TRAPI 1.2 has attributes on EdgeBindings, but not on NodeBindings.  This proposes extending the attributes to NodeBindings.

The use case for ARAGORN is when we add unasked-for nodes in response to a TRAPI query (usually as a result of result merging), we want to record why those particular nodes got added to a particular result.