### PR TITLE
Proposal for adding knowledge_types support to /meta_knowledge_graph

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -893,6 +893,16 @@ components:
           description: >-
             Object node category of this relationship edge.
           example: biolink:Protein
+        knowledge_types:
+          description: >-
+            A list of knowledge_types that are supported by the service.
+            If the knowledge_types is null, this means that only 'lookup'
+            is supported. Currently allowed values are 'lookup' or 'inferred'.
+          items:
+            string
+          minItems: 1
+          nullable: true
+          type: array
         attributes:
           type: array
           description: >-

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -899,7 +899,7 @@ components:
             If the knowledge_types is null, this means that only 'lookup'
             is supported. Currently allowed values are 'lookup' or 'inferred'.
           items:
-            string
+            type: string
           minItems: 1
           nullable: true
           type: array


### PR DESCRIPTION
Do we want to expand the MetaEdge class so that servers can advertise that they support knowledge_type=inferred for certain edges?