### PR TITLE
Add test_data_location in x-trapi

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -27,6 +27,7 @@ info:
       - LIST-ALL-SUPPORTED-OPERATION-IDS-HERE-OR-REMOVE-THIS-SECTION
     batch_size_limit: ADD-BATCH-SIZE-LIMIT-OR-REMOVE-IF-NO-LIMIT
     rate_limit: ADD-REQUEST-RATE-LIMIT-OR-REMOVE-IF-NO-LIMIT
+    test_data_location: ADD-URL-THAT-RESOLVES-TO-SRI-TESTING-HARNESS-DATA
     externalDocs:
       description: >-
         The values for version are restricted according to the regex in


### PR DESCRIPTION
Adding test_data_location:** URL that resolves to [SRI Testing harness](https://github.com/TranslatorSRI/SRI_testing) compliant test data in some public internet location (e.g. in the API implementation source code repository)

Sourced from https://github.com/NCATSTranslator/translator_extensions/pull/16/files