### PR TITLE
Fix ancestor handling in MKG

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -48,7 +48,7 @@ tags:
       Retrieve the meta knowledge graph representation of this
       TRAPI web service. KPs MUST provide all subject category - predicate -
       object category triplets that are supported by the service,
-      including all implied ancestor relationships. ARAs SHOULD provide
+      NOT including all implied ancestor relationships. ARAs SHOULD provide
       the union of all meta knowledge graphs of all the KPs that they can
       consult.
     externalDocs:


### PR DESCRIPTION
Following up more on the Slack discussion about ancestor relationships (https://app.slack.com/client/TSCGQ3XGB/C0156TX0VB2/thread/C0156TX0VB2-1657130646.008319), I have come to the conclusion that I was probably wrong about including all ancestors in the /meta_knowledge_graph.
1. Vlado remembered that we had decided to not include ancestors
2. In discussion with the ARAX team, we concluded that while ARAX & RTX-KG2 did once include ancestors, we stopped doing that and don't do it any more (presumably after a formal Translator decision)
3. In the MetaKnowledgeGraph section of TRAPI, it is very clear that ancestor inference is not to be include in the MKG:
```
    MetaKnowledgeGraph:
      type: object
      description: >-
        Knowledge-map representation of this TRAPI web service. The meta
        knowledge graph is composed of the union of most specific categories
        and predicates for each node and edge.
      properties:
        nodes:
          type: object
          description: >-
            Collection of the most specific node categories provided by
            this TRAPI web service, indexed by Biolink class CURIEs.
            A node category is only exposed here if there is
            node for which that is the most specific category available.
          additionalProperties:
            $ref: '#/components/schemas/MetaNode'
        edges:
          type: array
          description: >-
            List of the most specific edges/predicates provided by this TRAPI
            web service. A predicate is only exposed here if there is an edge
            for which the predicate is the most specific available.
```

Therefore, I propose to remedy the /meta_knowledge_graph description that seems to state the opposite. See diff.