### PR TITLE
Update reference to Workflow Operations Schema 1.3.2

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -236,7 +236,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           allOf:
-            - $ref: http://standards.ncats.io/workflow/1.0.0/schema
+            - $ref: http://standards.ncats.io/workflow/1.3.2/schema
           nullable: true
         submitter:
           type: string
@@ -284,7 +284,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           allOf:
-            - $ref: http://standards.ncats.io/workflow/1.0.0/schema
+            - $ref: http://standards.ncats.io/workflow/1.3.2/schema
           nullable: true
         submitter:
           type: string
@@ -334,7 +334,7 @@ components:
         workflow:
           description: List of workflow steps that were executed.
           allOf:
-            - $ref: http://standards.ncats.io/workflow/1.0.0/schema
+            - $ref: http://standards.ncats.io/workflow/1.3.2/schema
           nullable: true
       additionalProperties: true
       required:


### PR DESCRIPTION
This is potentially pretty disruptive, depending on how this is implemented. But yet it would seem like a major oversight to release TRAPI 1.3 still pointing to Workflow Operations Schema 1.0.0 when the latest is 1.3.2