### PR TITLE
`abstract`, `mixin` and `deprecated` `category` and `predicate` Biolink Model terms

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 The Translator Reasoner API (TRAPI) defines a standard HTTP API for communicating biomedical questions and answers. It leverages the [Biolink model](https://github.com/biolink/biolink-model/) to precisely describe the semantics of biological entities and relationships. TRAPI's graph-based query-knowledge-binding structure enables expressive yet concise description of biomedical questions and answers.
 
-TRAPI is described primarily by an [OpenAPI](https://github.com/OAI/OpenAPI-Specification) document [here](TranslatorReasonerAPI.yaml). The request/response structure is also documented in a more human-readable form [here](docs/reference.md).
+TRAPI is described primarily by an [OpenAPI](https://github.com/OAI/OpenAPI-Specification) document [here](TranslatorReasonerAPI.yaml). The complete request/response structure is also documented in a more human-readable form [here](docs/reference.md).
 
 ## Example
 
@@ -28,7 +28,7 @@ This question includes two nodes, "type-2 diabetes" and a "drug", and one edge, 
 }
 ```
 
-TRAPI requires the values for `ids`, `categories`, and `predicates` to be [CURIEs](https://en.wikipedia.org/wiki/CURIE) in order to unambiguously identify the specific entities, entity categories, and relationship predicates. The node and edge keys have no bearing on the query graph semantics, so you can choose simple placeholders (e.g. "n01"/"e02") or human-readable names, as above. Note that the node "drug" has no `ids`; that's what we want to find out! The query graph can thus be thought of as a template for an answer to the question.
+TRAPI requires the values for `ids`, `categories`, and `predicates` to be [CURIEs](https://en.wikipedia.org/wiki/CURIE) in order to unambiguously identify the specific entities, entity categories, and relationship predicates. Other constraints on these values are detailed in [the schema reference](docs/reference.md).  The node and edge keys have no bearing on the query graph semantics, so you can choose simple placeholders (e.g. "n01"/"e02") or human-readable names, as above. Note that the node "drug" has no `ids`; that's what we want to find out! The query graph can thus be thought of as a template for an answer to the question.
 
 ### Knowledge graph
 
@@ -46,7 +46,7 @@ A collection of biomedical knowledge can be represented in a similar format, but
 }
 ```
 
-In a "knowledge graph", the node keys _are_ semantically meaningful; they must be CURIEs identifying biomedical entities, equivalent to the `ids` from the query graph.
+In a "knowledge graph", the node keys _are_ semantically meaningful; they must be CURIEs identifying biomedical entities, equivalent to the `ids` from the query graph. Other constraints on these values are detailed in [the schema reference](docs/reference.md).  
 
 In TRAPI lingo, a knowledge graph is not an answer, it is just knowledge. Answering a question involves mapping knowledge onto a question.
 

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -601,6 +601,10 @@ components:
           nullable: true
         categories:
           type: array
+          description: >-
+            These should be Biolink Model categories and are allowed
+            to be of type 'abstract' or 'mixin' (only in QGraphs!).
+            Use of 'deprecated' categories should be avoided.
           items:
             $ref: '#/components/schemas/BiolinkEntity'
           minItems: 1
@@ -632,7 +636,7 @@ components:
     QEdge:
       type: object
       description: >-
-        An edge in the QueryGraph used as an filter pattern specification in a
+        An edge in the QueryGraph used as a filter pattern specification in a
         query. If the optional predicate property is not specified,
         it is assumed to be a wildcard match to the target knowledge space.
         If specified, the ontological inheritance hierarchy associated with
@@ -656,6 +660,10 @@ components:
           type: string
         predicates:
           type: array
+          description: >-
+            This should be a Biolink Model predicate and is allowed to be of
+            type 'abstract' or 'mixin' (only in QGraphs!). Use of 'deprecated'
+            predicates should be avoided.
           items:
             $ref: '#/components/schemas/BiolinkPredicate'
           minItems: 1
@@ -714,6 +722,10 @@ components:
           nullable: true
         categories:
           type: array
+          description: >-
+            These should be Biolink Model categories and are NOT allowed
+            to be of type 'abstract' or 'mixin'. Returning 'deprecated'
+            categories should also be avoided.
           items:
             $ref: '#/components/schemas/BiolinkEntity'
           nullable: true
@@ -818,6 +830,10 @@ components:
         resulting from a query upon the underlying knowledge source.
       properties:
         predicate:
+          description: >-
+            These should be Biolink Model predicate terms and are NOT allowed
+            to be of type 'abstract' or 'mixin'. Returning 'deprecated'
+            predicate terms should also be avoided.
           allOf:
             - $ref: '#/components/schemas/BiolinkPredicate'
           nullable: true

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -661,7 +661,7 @@ components:
         predicates:
           type: array
           description: >-
-            This should be a Biolink Model predicate and is allowed to be of
+            These should be Biolink Model predicates and are allowed to be of
             type 'abstract' or 'mixin' (only in QGraphs!). Use of 'deprecated'
             predicates should be avoided.
           items:

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -147,20 +147,20 @@ A node in the QueryGraph used to represent an entity in a query. If a CURIE is n
 Field Name | Type | Description
 ---|:---:|---
 ids | [[CURIE](#curie-)] | CURIE identifier for this node
-categories | [[BiolinkEntity](#biolinkentity-)] | 
+categories | [[BiolinkEntity](#biolinkentity-)] | **QNode** categories should be Biolink Model categories and are allowed to be of type `abstract` or `mixin` (only in QGraphs). Use of `deprecated` categories should be avoided.
 is_set | `boolean` | Boolean that if set to true, indicates that this QNode MAY have multiple KnowledgeGraph Nodes bound to it within each Result. The nodes in a set should be considered as a set of independent nodes, rather than a set of dependent nodes, i.e., the answer would still be valid if the nodes in the set were instead returned individually. Multiple QNodes may have is_set=True. If a QNode (n1) with is_set=True is connected to a QNode (n2) with is_set=False, each n1 must be connected to n2. If a QNode (n1) with is_set=True is connected to a QNode (n2) with is_set=True, each n1 must be connected to at least one n2.
 constraints | [[AttributeConstraint](#attributeconstraint-)] | A list of contraints applied to a query node. If there are multiple items, they must all be true (equivalent to AND)
 
 #### QEdge [?](https://github.com/NCATSTranslator/ReasonerAPI/blob/master/TranslatorReasonerAPI.yaml#L630:L700)
 
-An edge in the QueryGraph used as an filter pattern specification in a query. If the optional predicate property is not specified, it is assumed to be a wildcard match to the target knowledge space. If specified, the ontological inheritance hierarchy associated with the term provided is assumed, such that edge bindings returned may be an exact match to the given QEdge predicate term, or to a term that is a descendant of the QEdge predicate term.
+An edge in the QueryGraph used as a filter pattern specification in a query. If the optional predicate property is not specified, it is assumed to be a wildcard match to the target knowledge space. If specified, the ontological inheritance hierarchy associated with the term provided is assumed, such that edge bindings returned may be an exact match to the given QEdge predicate term, or to a term that is a descendant of the QEdge predicate term.
 
 ##### Fixed Fields
 
 Field Name | Type | Description
 ---|:---:|---
 knowledge_type | `string` | Indicates the type of knowledge that the client wants from the server between the subject and object. If the value is 'lookup', then the client wants direct lookup information from knowledge sources. If the value is 'inferred', then the client wants the server to get creative and connect the subject and object in more speculative and non-direct-lookup ways. If this property is absent or null, it MUST be assumed to mean 'lookup'. This feature is currently experimental and may be further extended in the future.
-predicates | [[BiolinkPredicate](#biolinkpredicate-)] | 
+predicates | [[BiolinkPredicate](#biolinkpredicate-)] | This should be a Biolink Model predicate and is allowed to be of type `abstract` or `mixin` (only in QGraphs). Use of `deprecated` predicates should be avoided.
 subject | `string` | **REQUIRED**. Corresponds to the map key identifier of the subject concept node anchoring the query filter pattern for the query relationship edge.
 object | `string` | **REQUIRED**. Corresponds to the map key identifier of the object concept node anchoring the query filter pattern for the query relationship edge.
 attribute_constraints | [[AttributeConstraint](#attributeconstraint-)] | A list of attribute contraints applied to a query edge. If there are multiple items, they must all be true (equivalent to AND)
@@ -175,7 +175,7 @@ A node in the KnowledgeGraph which represents some biomedical concept. Nodes are
 Field Name | Type | Description
 ---|:---:|---
 name | `string` | Formal name of the entity
-categories | [[BiolinkEntity](#biolinkentity-)] | 
+categories | [[BiolinkEntity](#biolinkentity-)] | These should be Biolink Model categories and are **_NOT_** allowed to be of type `abstract` or `mixin`. Returning `deprecated` categories should also be avoided.
 attributes | [[Attribute](#attribute-)] | A list of attributes describing the node
 
 #### Attribute [?](https://github.com/NCATSTranslator/ReasonerAPI/blob/master/TranslatorReasonerAPI.yaml#L725:L810)
@@ -203,7 +203,7 @@ A specification of the semantic relationship linking two concepts that are expre
 
 Field Name | Type | Description
 ---|:---:|---
-predicate | any | 
+predicate | any | These should be Biolink Model predicate terms and are **_NOT_** allowed to be of type `abstract` or `mixin`. Returning `deprecated` predicate terms should also be avoided.
 subject | [CURIE](#curie-) | **REQUIRED**. Corresponds to the map key CURIE of the subject concept node of this relationship edge.
 object | [CURIE](#curie-) | **REQUIRED**. Corresponds to the map key CURIE of the object concept node of this relationship edge.
 attributes | [[Attribute](#attribute-)] | A list of additional attributes for this edge
@@ -323,4 +323,3 @@ operator | `string` | **REQUIRED**. Relationship between the database value and 
 value | any | **REQUIRED**. Value of the attribute. May be any data type, including a list. If the value is a list and there are multiple items, at least one comparison must be true (equivalent to OR) unless the '===' operator is used. If 'value' is of data type 'object', the keys of the object MAY be treated as a list. A 'list' data type paired with the '>' or '<' operators will encode extraneous comparisons, but this is permitted as it is in SQL and other languages.
 unit_id | any | CURIE of the units of the value or list of values in the 'value' property. The Units of Measurement Ontology (UO) should be used if possible. The unit_id MUST be provided for (lists of) numerical values that correspond to a quantity that has units.
 unit_name | any | Term name that is associated with the CURIE of the units of the value or list of values in the 'value' property. The Units of Measurement Ontology (UO) SHOULD be used if possible. This property SHOULD be provided if a unit_id is provided. This is redundant but recommended for human readability.
-


### PR DESCRIPTION
Clarify documentation concerning use of `abstract`, `mixin` and `deprecated` `category` and `predicate` Biolink Model terms in TRAPI.