### PR TITLE
Update test_valid.py to use latest (>=3.1.4) reasoner-validator Python API

### DIFF
--- a/tests/test_valid.py
+++ b/tests/test_valid.py
@@ -1,12 +1,13 @@
 """OpenAPI 3.0 validation and examples validation."""
 import json
+from sys import stderr
 import os
 import pathlib
 import jsonschema
 import requests
 import yaml
 from jsonschema.exceptions import ValidationError
-from reasoner_validator import validate
+from reasoner_validator import TRAPISchemaValidator
 
 
 def test_valid():
@@ -34,12 +35,13 @@ def test_examples():
                 print(full_path)
                 example = json.load(f)
                 trapi_version_locally = spec['info']['x-trapi']['version']
+                validator = TRAPISchemaValidator(trapi_version=trapi_version_locally)
                 try:
-                    validate(
+                    validator.validate(
                         instance=example,
-                        component="Message",
-                        trapi_version=trapi_version_locally
+                        component="Message"
                     )
                 except ValidationError:
+                    print(validator.to_dict(), file=stderr)
                     raise ValueError('TRAPI example is not valid against the trapi_version specified!')
 


### PR DESCRIPTION
The latest reasoner-validator has a novel programmatic API not backwards compatible with 2.2.* releases.