### PR TITLE
Refactor of source retrieval provenance model

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -872,13 +872,14 @@ components:
           type: array
         sources:
           type: array
-          description: >- 
+          description: >-
             A list of RetrievalSource objects that provide information
-            about how a particular Information Resource served 
-            as a source from which the knowledge expressed in an Edge, 
-            or data used to generate this knowledge, was retrieved.       
+            about how a particular Information Resource served
+            as a source from which the knowledge expressed in an Edge,
+            or data used to generate this knowledge, was retrieved.
           items: '#/components/schemas/RetrievalSource'
-          nullable: false          
+          minItems: 1
+          nullable: false
       additionalProperties: false
       required:
         - object
@@ -1194,42 +1195,42 @@ components:
     RetrievalSource:
       type: object
       description: >-
-        Provides information about how a particular InformationResource 
+        Provides information about how a particular InformationResource
         served as a source from which knowledge expressed in an Edge, or
-        data used to generate this knowledge, was retrieved.  
+        data used to generate this knowledge, was retrieved.
       properties:
-        resource: 
+        resource:
           $ref: '#/components/schemas/CURIE'
           description: >-
-            The CURIE for an Information Resource that served as a source 
+            The CURIE for an Information Resource that served as a source
             of knowledge expressed in an Edge, or a source of data used to
             generate this knowledge.
           example: infores:drugbank
           nullable: false
-        resource_role: 
+        resource_role:
           type: string
           description: >-
-            The role played by the InformationResource in serving as a 
+            The role played by the InformationResource in serving as a
             source for an Edge. Note that a given Edge should have one
-            and only one 'primary' source, and may have any number of 
+            and only one 'primary' source, and may have any number of
             'aggregator' or 'supporting data' sources.
           enum:
-            - primary knowledge source
-            - aggregator knowledge source
-            - supporting data source
-        previous_resource:
+            - primary_knowledge_source
+            - aggregator_knowledge_source
+            - supporting_data_source
+        upstream_resources:
           type: array
-          items: 
+          items:
             $ref: '#/components/schemas/CURIE
-          description: >-  
-            An upstream InformationResource from which the resource 
-            being described directly retrieved a record of the knowledge 
-            expressed in the Edge, or data used to generate this knowledge. 
-            This is an array because there are cases where a merged Edge 
-            holds knowledge that was retrieved from multiple sources. e.g. 
+          description: >-
+            An upstream InformationResource from which the resource
+            being described directly retrieved a record of the knowledge
+            expressed in the Edge, or data used to generate this knowledge.
+            This is an array because there are cases where a merged Edge
+            holds knowledge that was retrieved from multiple sources. e.g.
             an Edge provided by the ARAGORN ARA can expressing knowledge it
-            retrieved from both the automat-mychem-info and molepro KPs, 
-            which both provided it with records of this single fact. 
+            retrieved from both the automat-mychem-info and molepro KPs,
+            which both provided it with records of this single fact.
           example: [infores:automat-mychem-info, infores:molepro]
       additional_properties: true
       required:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1194,25 +1194,25 @@ components:
     RetrievalSource:
       type: object
       description: >-
-        Provides information about how a particular InformationResource served 
-        as a source from which knowledge expressed in an Edge, or data used to
-        generate this knowledge, was retrieved.  
+        Provides information about how a particular InformationResource 
+        served as a source from which knowledge expressed in an Edge, or
+        data used to generate this knowledge, was retrieved.  
       properties:
         resource: 
           $ref: '#/components/schemas/CURIE'
           description: >-
-            The CURIE for an Information Resource that served as a source of 
-            knowledge expressed in an Edge, or a source of data used to generate this 
-            knowledge.
+            The CURIE for an Information Resource that served as a source 
+            of knowledge expressed in an Edge, or a source of data used to
+            generate this knowledge.
           example: infores:drugbank
           nullable: false
         resource_role: 
           type: string
           description: >-
-            The role played by the InformationResource in serving as a source for 
-            an Edge. Note that a given Edge should have one and only one 'primary' 
-            source, and may have any number of 'aggregator' or 'supporting data' 
-            sources.
+            The role played by the InformationResource in serving as a 
+            source for an Edge. Note that a given Edge should have one
+            and only one 'primary' source, and may have any number of 
+            'aggregator' or 'supporting data' sources.
           enum:
             - primary knowledge source
             - aggregator knowledge source
@@ -1222,13 +1222,14 @@ components:
           items: 
             $ref: '#/components/schemas/CURIE
           description: >-  
-            An upstream InformationResource from which the resource being described 
-            directly retrieved a record of the knowledge expressed in the Edge, or data 
-            used to generate this knowledge. This is an array because there are cases 
-            where a merged Edge holds knowledge that was retrieved from multiple sources.
-            e.g. an Edge provided by the ARAGORN ARA can expressing knowledge it retrieved 
-            from both the automat-mychem-info and molepro KPs, which both provided it with 
-            records of this single fact. 
+            An upstream InformationResource from which the resource 
+            being described directly retrieved a record of the knowledge 
+            expressed in the Edge, or data used to generate this knowledge. 
+            This is an array because there are cases where a merged Edge 
+            holds knowledge that was retrieved from multiple sources. e.g. 
+            an Edge provided by the ARAGORN ARA can expressing knowledge it
+            retrieved from both the automat-mychem-info and molepro KPs, 
+            which both provided it with records of this single fact. 
           example: [infores:automat-mychem-info, infores:molepro]
       additional_properties: true
       required:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -870,11 +870,21 @@ components:
             $ref: '#/components/schemas/Qualifier'
           nullable: true
           type: array
+        sources:
+          type: array
+          description: >- 
+            A list of RetrievalSource objects that provide information
+            about how a particular Information Resource served 
+            as a source from which the knowledge expressed in an Edge, 
+            or data used to generate this knowledge, was retrieved.       
+          items: '#/components/schemas/RetrievalSource'
+          nullable: false          
       additionalProperties: false
       required:
         - object
         - predicate
         - subject
+        - sources
     Qualifier:
       additionalProperties: false
       description: >-
@@ -1181,3 +1191,46 @@ components:
         - operator
         - value
       additionalProperties: false
+    RetrievalSource:
+      type: object
+      description: >-
+        Provides information about how a particular InformationResource served 
+        as a source from which knowledge expressed in an Edge, or data used to
+        generate this knowledge, was retrieved.  
+      properties:
+        resource: 
+          $ref: '#/components/schemas/CURIE'
+          description: >-
+            The CURIE for an Information Resource that served as a source of 
+            knowledge expressed in an Edge, or a source of data used to generate this 
+            knowledge.
+          example: infores:drugbank
+          nullable: false
+        resource_role: 
+          type: string
+          description: >-
+            The role played by the InformationResource in serving as a source for 
+            an Edge. Note that a given Edge should have one and only one 'primary' 
+            source, and may have any number of 'aggregator' or 'supporting data' 
+            sources.
+          enum:
+            - primary knowledge source
+            - aggregator knowledge source
+            - supporting data source
+        previous_resource:
+          type: array
+          items: 
+            $ref: '#/components/schemas/CURIE
+          description: >-  
+            An upstream InformationResource from which the resource being described 
+            directly retrieved a record of the knowledge expressed in the Edge, or data 
+            used to generate this knowledge. This is an array because there are cases 
+            where a merged Edge holds knowledge that was retrieved from multiple sources.
+            e.g. an Edge provided by the ARAGORN ARA can expressing knowledge it retrieved 
+            from both the automat-mychem-info and molepro KPs, which both provided it with 
+            records of this single fact. 
+          example: [infores:automat-mychem-info, infores:molepro]
+      additional_properties: true
+      required:
+        - resource
+        - resource_role

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1221,7 +1221,7 @@ components:
         upstream_resources:
           type: array
           items:
-            $ref: '#/components/schemas/CURIE
+            $ref: '#/components/schemas/CURIE'
           description: >-
             An upstream InformationResource from which the resource
             being described directly retrieved a record of the knowledge


### PR DESCRIPTION
Adding RetrievalSource object (and a reference to it form Edge) to support richer representations of retrieval provenance per #369.