### PR TITLE
Introduce a special property to make "negation" of edges more visible in a TRAPI message

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1072,6 +1072,15 @@ components:
           oneOf:
             - $ref: '#/components/schemas/CURIE'
           nullable: false
+        negated:
+          description: >-
+            Indicates whether the statement expressed in an Edge is
+            negated. If true, the statement is negated.  This also 
+            reflects the implementation in Biolink Model for 
+            negating an edge.
+          type: boolean
+          nullable: false
+          default: false
         attributes:
           description: A list of additional attributes for this edge
           items:

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1277,6 +1277,16 @@ components:
           description: >-
             Object node category of this relationship edge.
           example: biolink:Protein
+        can_be_negated:
+          type: boolean
+          description: >-
+            Indicates that this edge can be negated in the data source
+            presenting the edge. The edge property is different here from the
+            negated property in the Edge object in order to reuse the same edge
+            in the meta knowledge graph to represent both positive and negated 
+            edges of this type.
+          example: false
+          default: false
         knowledge_types:
           description: >-
             A list of knowledge_types that are supported by the service.


### PR DESCRIPTION
We discussed in the modeling group how to represent a 'negated' edge in our models either as a negated form of each of our predicates, e.g. `predicate: not_affects` and `predicate: affects` or as an edge property `negation`.  Ultimately, the DM group decided to include a `negation` edge property ([revisit the discussion and vote here](https://github.com/biolink/biolink-model/discussions/826)), with the caveat that `negation` should _never_ be ignored downstream and should _always_ be shown.  Right now in TRAPI, the `negation` edge property would be treated in TRAPI like any other `attribute`.  

Groups making negated edges still express concern that the negation property will be ignored or less visible than necessary for groups downstream (and ultimately users).   This PR attempts to give more transparency to the `negation` property via a specific property on an edge, as well as adding a flag to MetaEdge so that a resource an alert users that an edge might have both positive and negated edges. 
