### PR TITLE
Change reasoner_id to resource_id

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -644,9 +644,9 @@ components:
         supporting the analysis (e.g. method or data that supported
         generation of the score).
       properties:
-        reasoner_id:
+        resource_id:
           $ref: '#/components/schemas/CURIE'
-          description: The id of the service generating and using this Anlysis
+          description: The id of the resource generating this Analysis
         score:
           type: number
           format: float


### PR DESCRIPTION
This is a proposed CHANGE to TRAPI 1.4-beta, to be included in ongoing implementations. As discussed in the TRAPI call today, this property is required and KPs are required to use it, so use the more generic term resource_id