### PR TITLE
Update resource to resource_id

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1474,7 +1474,7 @@ components:
         served as a source from which knowledge expressed in an Edge, or
         data used to generate this knowledge, was retrieved.
       properties:
-        resource:
+        resource_id:
           $ref: '#/components/schemas/CURIE'
           description: >-
             The CURIE for an Information Resource that served as a source
@@ -1489,7 +1489,7 @@ components:
             source for an Edge. Note that a given Edge should have one
             and only one 'primary' source, and may have any number of
             'aggregator' or 'supporting data' sources.
-        upstream_resources:
+        upstream_resource_ids:
           type: array
           items:
             $ref: '#/components/schemas/CURIE'


### PR DESCRIPTION
This is a proposed CHANGE to TRAPI 1.4-beta, to be included in ongoing implementations. As discussed in the TRAPI call today, the `resource` and `upstream_resources` properties go against our convention that such properties that are a CURIE should end in _id (like subject_id, object_id, attribute_type_id, etc. Rename these to `resource_id` and `upstream_resource_ids`