### PR TITLE
We agreed to tag as 1.4.0

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -22,7 +22,7 @@ info:
       url: https://github.com/NCATSTranslator/translator_extensions/blob/\
         production/x-translator/
   x-trapi:
-    version: 1.4.0-dev
+    version: 1.4.0
     asyncquery: REPLACE-WITH-true-IF-/asyncquery-IS-IMPLEMENTED-ELSE-false
     operations:
       - LIST-ALL-SUPPORTED-OPERATION-IDS-HERE-OR-REMOVE-THIS-SECTION


### PR DESCRIPTION
Per yesterday's call, we will tag instances in SmartAPI at 1.4.0. Updating beta template to advertise 1.4.0