### PR TITLE
update-TRAPI-1.4.1-to-workflows-1.3.5

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -278,7 +278,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           oneOf:
-            - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+            - $ref: http://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         submitter:
           type: string

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -326,7 +326,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           oneOf:
-            - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+            - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         submitter:
           type: string

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -278,7 +278,7 @@ components:
         workflow:
           description: List of workflow steps to be executed.
           oneOf:
-            - $ref: http://standards.ncats.io/workflow/1.3.5/schema
+            - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         submitter:
           type: string
@@ -452,7 +452,7 @@ components:
         workflow:
           description: List of workflow steps that were executed.
           oneOf:
-            - $ref: http://standards.ncats.io/workflow/1.3.4/schema
+            - $ref: https://standards.ncats.io/workflow/1.3.5/schema
           nullable: true
         schema_version:
           type: string


### PR DESCRIPTION
The latest TRAPI Response.workflow value is defined by the operations and workflows (W&O) schema at http://standards.ncats.io/workflow/.  

TRAPI 1.3.0 pointed to the http://standards.ncats.io/workflow/1.3.2/schema, which was discovered to have validation issues. 

An initial update to a 1.3.3 schemata release missed updating the internal **`$id`** fields (and the workflow item cross **`$ref`** field) to dereference 1.3.3.  At the same time, it was noted that the '_operations_' schema had significant internal duplication, suggesting systematic refactoring into additional (shared) sub-schemata.  Both issues were essentially repaired in release 1.3.4.

However, the extracted sub-schemata for both the **`AllowedList`** and **`DenyList`** JSON properties was left too open ended, allowing for additional object keys - an undesirable loophole.  To provide a tighter semantic constraint on those two sub-schemata,  the 

```yaml
"additionalProperties": false
```
directive was added to each, and the schemata re-released as 1.3.5 - the current standard. However, although TRAPI was updated by [1.4.0-beta4](https://github.com/NCATSTranslator/ReasonerAPI/tree/v1.4.0-beta4) to point to the W&O schema 1.3.4, the latest 1.4.2 has not yet been updated to point to 1.3.5.

_Thus, this PR updates the current TRAPI release 1.4.2 to point to the release 1.3.5 workflow schema  (http://standards.ncats.io/workflow/1.3.5/schema)._