### PR TITLE
Fix sample trapi

### DIFF
--- a/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide1-4.md
+++ b/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide1-4.md
@@ -820,7 +820,7 @@ Now we can put these two sections back together to get the final message.
     "query_graph": {
         "nodes": {
             "n0": {
-                "id": "diabetes"
+                "ids": ["diabetes"]
             },
             "n1": {
                 "categories": ["drug"]
@@ -836,7 +836,7 @@ Now we can put these two sections back together to get the final message.
     },
     "knowledge_graph": {
         "nodes": {
-            "diabetes": {"ids": ["MONDO:0005148"]},
+            "diabetes": {"name": ["MONDO:0005148"]},
             "metformin":  {"categories": ["biolink:Drug"]}
         },
         "edges": {

--- a/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide1-4.md
+++ b/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide1-4.md
@@ -828,7 +828,7 @@ Now we can put these two sections back together to get the final message.
         },
         "edges": {
             "e0": {
-                "predicates":["treats],
+                "predicates":["treats"],
                 "subject": "n1",
                 "object": "n0"
             }
@@ -836,8 +836,8 @@ Now we can put these two sections back together to get the final message.
     },
     "knowledge_graph": {
         "nodes": {
-            "diabetes": {node_info},
-            "metformin": {node_info}
+            "diabetes": {"ids": ["MONDO:0005148"]},
+            "metformin":  {"categories": ["biolink:Drug"]}
         },
         "edges": {
             "e01": {

--- a/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide1-4.md
+++ b/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide1-4.md
@@ -813,7 +813,7 @@ Result generation for KP's is also relatively simple. In this case, we just migr
 
 ## TRAPI 1.4 Example Message
 
-Now we can put these two sections back together to get the final message.
+Now we can put these two sections back together to get the final message. The various JSON properties are given some credible final values not all present in the above text (but this allows this sample to validate properly using the reasoner-validator):
 
 ```
 "message": {

--- a/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide1-4.md
+++ b/ImplementationGuidance/MigrationGuides/MigrationAndImplementationGuide1-4.md
@@ -823,12 +823,12 @@ Now we can put these two sections back together to get the final message.
                 "ids": ["diabetes"]
             },
             "n1": {
-                "categories": ["drug"]
+                "categories": ["biolink:Drug"]
             }
         },
         "edges": {
             "e0": {
-                "predicates":["treats"],
+                "predicates":["biolink:treats"],
                 "subject": "n1",
                 "object": "n0"
             }
@@ -836,14 +836,14 @@ Now we can put these two sections back together to get the final message.
     },
     "knowledge_graph": {
         "nodes": {
-            "diabetes": {"name": ["MONDO:0005148"]},
-            "metformin":  {"categories": ["biolink:Drug"]}
+            "MONDO:0005148": {"name": "diabetes", "categories": ["biolink:Disease"]},
+            "ncats.drug:9100L32L2N":  {"name": "metformin", "categories": ["biolink:Drug"]}
         },
         "edges": {
             "e01": {
-                "subject": "metformin",
-                "object": "diabetes",
-                "predicate": "treats",
+                "subject": "ncats.drug:9100L32L2N",
+                "object": "MONDO:0005148",
+                "predicate": "biolink:treats",
                 "attributes": [],
                 "sources":[
                     {
@@ -874,12 +874,12 @@ Now we can put these two sections back together to get the final message.
             "node_bindings": {
                 "n0": [
                     {
-                        "id": "diabetes"
+                        "id": "MONDO:0005148"
                     }
                 ],
                 "n1": [
                     {
-                        "id": "metformin"
+                        "id": "ncats.drug:9100L32L2N"
                     }
                 ]
             },


### PR DESCRIPTION
Fixed the last block of JSON in the implementation guide to be well-formed TRAPI, so that folks can copy and paste it to validate it inside the reasoner-validator, as a sample.