### PR TITLE
Set id Update TranslatorReasonerAPI.yaml

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -874,9 +874,9 @@ components:
             A CURIE identifier (or list of identifiers) for this node. 
             The 'ids' field will hold a list of CURIEs only in the case of a
             BATCH set_interpretation, where each CURIE is to be queried 
-            separately. If a set of queried CURIEs is to be considered as a  
-            set, as under a MANY or ALL set_interpretation, the 'ids' field 
-            will hold a single id representing this set. The individual members 
+            separately. If a list of queried CURIEs is to be considered as a  
+            set (as under a MANY or ALL set_interpretation), the 'ids' field 
+            will hold a single id representing this set, and the individual members 
             of this set will be captured in a separate 'member_ids' field. 
             Note that the set id MUST be created as a UUID by the system that 
             defines the queried set, using a centralized nodenorm service. 

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -873,7 +873,7 @@ components:
           description: >-
             A CURIE identifier (or list of identifiers) for this node. 
             The 'ids' field will hold a list of CURIEs only in the case of a
-            BATCH set_interpretation, where each CURIE is to be queried 
+            BATCH set_interpretation, where each CURIE is queried 
             separately. If a list of queried CURIEs is to be considered as a  
             set (as under a MANY or ALL set_interpretation), the 'ids' field 
             will hold a single id representing this set, and the individual members 

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -870,7 +870,19 @@ components:
             $ref: '#/components/schemas/CURIE'
           minItems: 1
           example: [OMIM:603903]
-          description: CURIE identifier for this node
+          description: >-
+            A CURIE identifier (or list of identifiers) for this node. 
+            The 'ids' field will hold a list of CURIEs only in the case of a
+            BATCH set_interpretation, where each CURIE is to be queried 
+            separately. If a set of queried CURIEs is to be considered as a  
+            set, as under a MANY or ALL set_interpretation, the 'ids' field 
+            will hold a single id representing this set. The individual members 
+            of this set will be captured in a separate 'member_ids' field. 
+            Note that the set id MUST be created as a UUID by the system that 
+            defines the queried set, using a centralized nodenorm service. 
+            Note also that downstream systems MUST re-use the original set UUID 
+            in the messages they create/send, which will facilitate merging or 
+            caching operations.
           nullable: true
         categories:
           type: array
@@ -898,6 +910,17 @@ components:
             - ALL
             - MANY
           nullable: true
+        member_ids:
+          type: array
+          description: >-
+            A list of CURIE identifiers for members of a queried set. This 
+            field MUST be populated under a set_interpretation of MANY
+            or ALL, when the 'ids' field holds a UUID representing the set 
+            itself. This field MUST NOT be used under a set_interpretation 
+            of BATCH.
+          nullable: true
+          items:
+            - $ref: '#/components/schemas/CURIE'
         constraints:
           type: array
           description: >-


### PR DESCRIPTION
Alternate proposal for representing set ids and set members in a Qnode, per the suggestion [here](https://github.com/NCATSTranslator/ReasonerAPI/pull/480#issuecomment-2047599410).

Note that the benefit of this over the proposal in #480 is that node binding in Results can continue to work as they currently do - where q nodes here are bound to curies in the `ids` field and not some new field like `set_id`.