### PR TITLE
The value of the  items property in the member_ids property should NOT be a YAML list!

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -920,7 +920,7 @@ components:
             of BATCH.
           nullable: true
           items:
-            - $ref: '#/components/schemas/CURIE'
+            $ref: '#/components/schemas/CURIE'
         constraints:
           type: array
           description: >-


### PR DESCRIPTION
The value of the  **`items`** property in the **`member_ids`** property should NOT be a YAML list!

```yaml
        member_ids:
          type: array
          # etc...
          items:
            $ref: '#/components/schemas/CURIE'   # <= this is a 'scalar' argument to **`items`**, not a list
```