### PR TITLE
fix indent for MetaQualifier - applicable_values - example

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1421,7 +1421,7 @@ components:
                 The list of values that are possible for this qualifier.
           items:
             type: string
-            example: [expression, activity, abundance, degradation]
+          example: [expression, activity, abundance, degradation]
       required:
         - qualifier_type_id
     MetaAttribute:


### PR DESCRIPTION
The example for MetaQualifier - applicable_values was indented once too far such that it appeared under MetaQualifier - applicable_values - items instead. This commit corrects the indent level.