### PR TITLE
Pathfinder proposal edits

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -716,14 +716,14 @@ components:
             items:
               $ref: '#/components/schemas/EdgeBinding'
         path_bindings:
-          additionalProperties:
-            items:
-              $ref: '#/components/schemas/PathBinding'
-            type: array
+          type: object
           description: >-
             The dictionary of input Query Graph paths to Analysis paths, specifically only
             for pathfinder queries.
-          type: object
+          additionalProperties:
+            type: array
+            items:
+              $ref: '#/components/schemas/PathBinding'
         support_graphs:
           type: array
           description: >-
@@ -781,27 +781,26 @@ components:
         - id
         - attributes
     PathBinding:
-      additionalProperties: true
+      type: object
       description: >-
         A instance of PathBinding is a single binding of an input QueryGraph path
         (the key to this object) with the AuxiliaryGraph id containing a list of
         edges in the path.
       properties:
         id:
-          description: The key identifier of a specific auxiliary graph.
           type: string
+          description: The key identifier of a specific auxiliary graph.
         attributes:
+          type: array
           description: >-
             A list of attributes providing further information about the path
             binding.
           items:
             $ref: '#/components/schemas/Attribute'
           nullable: true
-          type: array
+      additionalProperties: true
       required:
-      - id
-      title: PathBinding
-      type: object
+        - id
     AuxiliaryGraph:
       type: object
       description: >-
@@ -887,14 +886,14 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/QEdge'
         paths:
-          additionalProperties:
-            $ref: '#/components/schemas/QPath'
+          type: object
           description: >-
             The QueryGraph path specification, used only for pathfinder type
             queries. The keys of this map are unique path identifiers and the
             corresponding values include the constraints on bound paths, in
             addition to specifying the subject, object, and intermediate QNodes.
-          type: object
+          additionalProperties:
+            $ref: '#/components/schemas/QPath'
       additionalProperties: true
       required:
         - nodes
@@ -1047,32 +1046,33 @@ components:
         - subject
         - object
     QPath:
-      additionalProperties: true
+      type: object
       description: >-
         A path in the QueryGraph used for pathfinder queries only, flowing from
         subject to intermediate nodes, if any, to object.
       properties:
         subject:
+          type: string
           description: >-
             Corresponds to the map key identifier of the subject concept node for
             the start of the queried path.
           example: n0
-          type: string
         object:
+          type: string
           description: >-
             Corresponds to the map key identifier of the object concept node for
             the end of the queried path.
           example: n1
-          type: string
         intermediate_nodes:
-          default: []
+          type: array
           description: >-
             An ordered list of intermediate nodes, if any, in the direction of 
             subject to object in the query path.
           items:
             type: string
-          type: array
+          default: []
         predicates:
+          type: array
           description: >-
             These should be Biolink Model predicates and are allowed to be of type
             'abstract' or 'mixin' (only in QGraphs!). Use of 'deprecated'
@@ -1081,22 +1081,20 @@ components:
             $ref: '#/components/schemas/BiolinkPredicate'
           minItems: 1
           nullable: true
-          type: array
         attribute_constraints:
-          default: []
+          type: array
           description: >-
             A list of attribute contraints applied to a query edge. If there are
             multiple items, they must all be true (equivalent to AND)
           items:
             $ref: '#/components/schemas/AttributeConstraint'
-          type: array
+          default: []
+      additionalProperties: true
       required:
-      - intermediate_nodes
-      - object
-      - predicates
-      - subject
-      title: QPath
-      type: object
+        - intermediate_nodes
+        - object
+        - predicates
+        - subject
     Node:
       type: object
       description: >-

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -627,7 +627,9 @@ components:
             The list of all Analysis components that contribute to the result.
             See below for Analysis components.
           items:
-            $ref: '#/components/schemas/Analysis'
+            oneOf:
+              - $ref: '#/components/schemas/RegularAnalysis'
+              - $ref: '#/components/schemas/PathfinderAnalysis'
           minItems: 0
           nullable: false 
       additionalProperties: true
@@ -679,7 +681,7 @@ components:
       required:
         - id
         - attributes
-    Analysis:
+    SharedAnalysisProperties:
       type: object
       description: >-
         An analysis is a dictionary that contains information about
@@ -702,28 +704,6 @@ components:
             relevance or confidence of this result relative to others in the
             returned set. Higher MUST be better.
           nullable: true
-        edge_bindings:
-          type: object
-          description: >-
-            The dictionary of input Query Graph to Knowledge Graph edge
-            bindings where the dictionary keys are the key identifiers of the
-            Query Graph edges and the associated values of those keys are
-            instances of EdgeBinding schema type (see below). This value is an
-            array of EdgeBindings since a given query edge may resolve to
-            multiple Knowledge Graph Edges.
-          additionalProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/EdgeBinding'
-        path_bindings:
-          type: object
-          description: >-
-            The dictionary of input Query Graph paths to Analysis paths, specifically only
-            for pathfinder queries.
-          additionalProperties:
-            type: array
-            items:
-              $ref: '#/components/schemas/PathBinding'
         support_graphs:
           type: array
           description: >-
@@ -750,6 +730,47 @@ components:
       additionalProperties: true
       required:
         - resource_id
+    RegularAnalysis:
+      allOf: 
+        - $ref: '#/components/schemas/SharedAnalysisProperties'
+        - type: object
+          description: >-
+            An analysis for results from a non-Pathfinder query SHOULD have
+            edge_bindings and SHOULD NOT have path_bindings
+          required: 
+            - edge_bindings
+          properties:
+            edge_bindings:
+              type: object
+              description: >-
+                The dictionary of input Query Graph to Knowledge Graph edge
+                bindings where the dictionary keys are the key identifiers of
+                the Query Graph edges and the associated values of those keys
+                are instances of EdgeBinding schema type (see below). This
+                value is an array of EdgeBindings since a given query edge may
+                resolve to multiple Knowledge Graph Edges.
+              additionalProperties:
+                type: array
+                items:
+                  $ref: '#/components/schemas/EdgeBinding'
+    PathfinderAnalysis:
+      allOf: 
+        - $ref: '#/components/schemas/SharedAnalysisProperties'
+        - type: object
+          description: >-
+            An analysis for results from a Pathfinder query SHOULD have
+            path_bindings and SHOULD NOT have edge_bindings
+          required: 
+            - path_bindings
+          properties:
+            path_bindings:
+              additionalProperties:
+                items:
+                  $ref: '#/components/schemas/PathBinding'
+                type: array
+              description: >-
+                The dictionary of input Query Graph paths to Analysis paths, specifically only for pathfinder queries.
+              type: object
     EdgeBinding:
       type: object
       description: >-

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -720,8 +720,9 @@ components:
             items:
               $ref: '#/components/schemas/PathBinding'
             type: array
-          description: The dictionary of input Query Graph paths to Analysis paths,
-            specifically only for pathfinder queries.
+          description: >-
+            The dictionary of input Query Graph paths to Analysis paths, specifically only
+            for pathfinder queries.
           type: object
         support_graphs:
           type: array
@@ -781,16 +782,18 @@ components:
         - attributes
     PathBinding:
       additionalProperties: true
-      description: A instance of PathBinding is a single binding of an input Query
-        Graph path (the key to this object) with the auxiary graph id containing
-        a list of edges in the path.
+      description: >-
+        A instance of PathBinding is a single binding of an input QueryGraph path
+        (the key to this object) with the AuxiliaryGraph id containing a list of
+        edges in the path.
       properties:
         id:
           description: The key identifier of a specific auxiliary graph.
           type: string
         attributes:
-          description: A list of attributes providing further information about the
-            path binding.
+          description: >-
+            A list of attributes providing further information about the path
+            binding.
           items:
             $ref: '#/components/schemas/Attribute'
           nullable: true
@@ -886,11 +889,11 @@ components:
         paths:
           additionalProperties:
             $ref: '#/components/schemas/QPath'
-          description: The QueryGraph path specification, used only for pathfinder
-            type queries. The keys of this map are unique path
-            identifiers and the corresponding values include the constraints on bound
-            paths, in addition to specifying the subject, object, and intermediate
-            QNodes.
+          description: >-
+            The QueryGraph path specification, used only for pathfinder type
+            queries. The keys of this map are unique path identifiers and the
+            corresponding values include the constraints on bound paths, in
+            addition to specifying the subject, object, and intermediate QNodes.
           type: object
       additionalProperties: true
       required:
@@ -1045,29 +1048,34 @@ components:
         - object
     QPath:
       additionalProperties: true
-      description: A path in the QueryGraph used for pathfinder queries only, flowing
-        from subject to intermediate nodes, if any, to object.
+      description: >-
+        A path in the QueryGraph used for pathfinder queries only, flowing from
+        subject to intermediate nodes, if any, to object.
       properties:
         subject:
-          description: Corresponds to the map key identifier of the subject concept
-            node for the start of the queried path.
+          description: >-
+            Corresponds to the map key identifier of the subject concept node for
+            the start of the queried path.
           example: n0
           type: string
         object:
-          description: Corresponds to the map key identifier of the object concept
-            node for the end of the queried path.
+          description: >-
+            Corresponds to the map key identifier of the object concept node for
+            the end of the queried path.
           example: n1
           type: string
         intermediate_nodes:
           default: []
-          description: An ordered list of intermediate nodes, if any, in the direction of
+          description: >-
+            An ordered list of intermediate nodes, if any, in the direction of 
             subject to object in the query path.
           items:
             type: string
           type: array
         predicates:
-          description: These should be Biolink Model predicates and are allowed to
-            be of type 'abstract' or 'mixin' (only in QGraphs!). Use of 'deprecated'
+          description: >-
+            These should be Biolink Model predicates and are allowed to be of type
+            'abstract' or 'mixin' (only in QGraphs!). Use of 'deprecated'
             predicates should be avoided.
           items:
             $ref: '#/components/schemas/BiolinkPredicate'
@@ -1076,8 +1084,9 @@ components:
           type: array
         attribute_constraints:
           default: []
-          description: A list of attribute contraints applied to a query edge. If
-            there are multiple items, they must all be true (equivalent to AND)
+          description: >-
+            A list of attribute contraints applied to a query edge. If there are
+            multiple items, they must all be true (equivalent to AND)
           items:
             $ref: '#/components/schemas/AttributeConstraint'
           type: array

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -529,7 +529,8 @@ components:
             QueryGraph object that contains a serialization of a query in the
             form of a graph
           oneOf:
-            - $ref: '#/components/schemas/QueryGraph'
+            - $ref: '#/components/schemas/RegularQueryGraph'
+            - $ref: '#/components/schemas/PathfinderQueryGraph'
           nullable: true
         knowledge_graph:
           description: >-
@@ -882,7 +883,7 @@ components:
       required:
         - nodes
         - edges
-    QueryGraph:
+    SharedQueryGraphProperties:
       type: object
       description: >-
         A graph representing a biomedical question. It serves as a template for
@@ -897,27 +898,47 @@ components:
             on bound nodes.
           additionalProperties:
             $ref: '#/components/schemas/QNode'
-        edges:
-          type: object
-          description: >-
-            The edge specifications. The keys of this map are unique edge
-            identifiers and the corresponding values include the constraints
-            on bound edges, in addition to specifying the subject and object
-            QNodes.
-          additionalProperties:
-            $ref: '#/components/schemas/QEdge'
-        paths:
-          type: object
-          description: >-
-            The QueryGraph path specification, used only for pathfinder type
-            queries. The keys of this map are unique path identifiers and the
-            corresponding values include the constraints on bound paths, in
-            addition to specifying the subject, object, and intermediate QNodes.
-          additionalProperties:
-            $ref: '#/components/schemas/QPath'
       additionalProperties: true
       required:
         - nodes
+    RegularQueryGraph:
+      allOf: 
+        - $ref: '#/components/schemas/SharedQueryGraphProperties'
+        - type: object
+          description: >-
+            A non-Pathfinder query SHOULD have edges following the QEdge schema
+            and SHOULD NOT have paths
+          required: 
+            - edges
+          properties:
+            edges:
+              type: object
+              description: >-
+                The edge specifications. The keys of this map are unique edge
+                identifiers and the corresponding values include the constraints
+                on bound edges, in addition to specifying the subject and object
+                QNodes.
+              additionalProperties:
+                $ref: '#/components/schemas/QEdge'
+    PathfinderQueryGraph:
+      allOf: 
+        - $ref: '#/components/schemas/SharedQueryGraphProperties'
+        - type: object
+          description: >-
+            A Pathfinder query SHOULD have paths following the QPath schema
+            and SHOULD NOT have edges
+          required: 
+            - paths
+          properties:
+            paths:
+              type: object
+              description: >-
+                The QueryGraph path specification, used only for pathfinder type
+                queries. The keys of this map are unique path identifiers and the
+                corresponding values include the constraints on bound paths, in
+                addition to specifying the subject, object, and intermediate QNodes.
+              additionalProperties:
+                $ref: '#/components/schemas/QPath'
     QNode:
       type: object
       description: A node in the QueryGraph used to represent an entity in a


### PR DESCRIPTION
my proposed solutions for Analysis/QueryGraph that are backward-compatible and add the Pathfinder features. The branch also has edits for formatting, so new sections match the rest of the document

I've verified that the schema works as-expected using https://smart-api.info/editor to review the "parsed" schema.

Notes: I used allOf and oneOf, as described in the OpenAPI's documentation on [Inheritance/model composition](https://swagger.io/docs/specification/v3_0/data-models/inheritance-and-polymorphism/) and [oneOf](https://swagger.io/docs/specification/v3_0/data-models/oneof-anyof-allof-not/).

