### PR TITLE
Making some `attributes` not required and trying to handle not-required/required properties consistently

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -676,12 +676,11 @@ components:
             result.
           items:
             $ref: '#/components/schemas/Attribute'
-          minItems: 0
-          nullable: false
+          minItems: 1
+          nullable: true
       additionalProperties: true
       required:
         - id
-        - attributes
     BaseAnalysis:
       type: object
       description: >-
@@ -796,12 +795,11 @@ components:
             result.
           items:
             $ref: '#/components/schemas/Attribute'
-          minItems: 0
-          nullable: false
+          minItems: 1
+          nullable: true
       additionalProperties: true
       required:
         - id
-        - attributes
     PathBinding:
       type: object
       description: >-
@@ -846,12 +844,11 @@ components:
             Attributes of the Auxiliary Graph
           items:
             $ref: '#/components/schemas/Attribute'
-          minItems: 0
-          nullable: false
+          minItems: 1
+          nullable: true
       additionalProperties: true
       required:
         - edges
-        - attributes
     KnowledgeGraph:
       type: object
       description: >-

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -267,7 +267,6 @@ components:
         message:
           oneOf:
             - $ref: '#/components/schemas/Message'
-          nullable: false
           description: >-
             The query Message is a serialization of the user request. Content
             of the Message object depends on the intended TRAPI operation. For
@@ -315,7 +314,6 @@ components:
       properties:
         callback:
           type: string
-          nullable: false
           format: uri
           pattern: ^https?://
           description: >-
@@ -330,7 +328,6 @@ components:
         message:
           oneOf:
             - $ref: '#/components/schemas/Message'
-          nullable: false
           description: >-
             The query Message is a serialization of the user request. Content
             of the Message object depends on the intended TRAPI operation. For
@@ -396,7 +393,6 @@ components:
             the job.
           type: string
           example: rXEOAosN3L
-          nullable: false
       additionalProperties: true
       required:
         - job_id
@@ -412,14 +408,12 @@ components:
             Queued, Running, Completed, Failed
           type: string
           example: Running
-          nullable: false
         description:
           description: >-
             A brief human-readable description of the current state
             or summary of the problem if the status is Failed.
           type: string
           example: Callback URL returned 500
-          nullable: false
         logs:
           description: >-
             A list of LogEntry items, containing errors, warnings, debugging
@@ -431,7 +425,6 @@ components:
           items:
             $ref: '#/components/schemas/LogEntry'
           minItems: 1
-          nullable: false
         response_url:
           description: >-
             Optional URL that can be queried to restrieve the full TRAPI
@@ -460,7 +453,6 @@ components:
             graph, and results).
           oneOf:
             - $ref: '#/components/schemas/Message'
-          nullable: false
         status:
           description: >-
             One of a standardized set of short codes,
@@ -578,7 +570,6 @@ components:
             the timezone offset must be provided
             (e.g. 2020-09-03T18:13:49-04:00).
           example: '2020-09-03T18:13:49+00:00'
-          nullable: false
         level:
           oneOf:
             - $ref: '#/components/schemas/LogLevel'
@@ -593,7 +584,6 @@ components:
         message:
           type: string
           description: A human-readable log message
-          nullable: false
       additionalProperties: true
       required:
         - timestamp
@@ -629,7 +619,6 @@ components:
               $ref: '#/components/schemas/NodeBinding'
             minItems: 1
           minProperties: 1
-          nullable: false 
         analyses:
           type: array
           description: >-
@@ -640,7 +629,6 @@ components:
               - $ref: '#/components/schemas/Analysis'
               - $ref: '#/components/schemas/PathfinderAnalysis'
           minItems: 1
-          nullable: false 
       additionalProperties: true
       required:
         - node_bindings
@@ -658,7 +646,6 @@ components:
         id:
           oneOf:
             - $ref: '#/components/schemas/CURIE'
-          nullable: false
           description: >-
             The CURIE of a Node within the Knowledge Graph.
         query_id:
@@ -766,7 +753,6 @@ components:
                   $ref: '#/components/schemas/EdgeBinding'
                 minItems: 1
               minProperties: 1
-              nullable: false
     PathfinderAnalysis:
       allOf: 
         - $ref: '#/components/schemas/BaseAnalysis'
@@ -787,7 +773,6 @@ components:
                   $ref: '#/components/schemas/PathBinding'
                 minItems: 1
               minProperties: 1
-              nullable: false
     EdgeBinding:
       type: object
       description: >-
@@ -802,7 +787,6 @@ components:
         id:
           type: string
           description: The key identifier of a specific KnowledgeGraph Edge.
-          nullable: false
         attributes:
           type: array
           description: >-
@@ -828,7 +812,6 @@ components:
         id:
           type: string
           description: The key identifier of a specific auxiliary graph.
-          nullable: false
       additionalProperties: true
       required:
         - id
@@ -854,7 +837,6 @@ components:
             between the edges that form this Auxiliary Graph.
           items:
             type: string
-          nullable: false
           minItems: 1
         attributes:
           type: array
@@ -885,7 +867,6 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/Node'
           minProperties: 1
-          nullable: false
         edges:
           type: object
           description: >-
@@ -894,7 +875,6 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/Edge'
           minProperties: 1
-          nullable: false
       additionalProperties: true
       required:
         - nodes
@@ -915,7 +895,6 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/QNode'
           minProperties: 1
-          nullable: false
       additionalProperties: true
       required:
         - nodes
@@ -939,7 +918,6 @@ components:
               additionalProperties:
                 $ref: '#/components/schemas/QEdge'
               minProperties: 1
-              nullable: false
     PathfinderQueryGraph:
       allOf: 
         - $ref: '#/components/schemas/BaseQueryGraph'
@@ -961,7 +939,6 @@ components:
                 $ref: '#/components/schemas/QPath'
               minProperties: 1
               maxProperties: 1
-              nullable: false
     QNode:
       type: object
       description: A node in the QueryGraph used to represent an entity in a
@@ -1079,7 +1056,6 @@ components:
             Corresponds to the map key identifier of the
             subject concept node anchoring the query filter
             pattern for the query relationship edge.
-          nullable: false
         object:
           type: string
           example: https://www.uniprot.org/uniprot/P00738
@@ -1087,7 +1063,6 @@ components:
             Corresponds to the map key identifier of the
             object concept node anchoring the query filter
             pattern for the query relationship edge.
-          nullable: false
         attribute_constraints:
           type: array
           description: >-
@@ -1130,14 +1105,12 @@ components:
             Corresponds to the map key identifier of the subject concept node for
             the start of the queried path.
           example: n0
-          nullable: false
         object:
           type: string
           description: >-
             Corresponds to the map key identifier of the object concept node for
             the end of the queried path.
           example: n1
-          nullable: false
         predicates:
           type: array
           description: >-
@@ -1204,7 +1177,6 @@ components:
           items:
             $ref: '#/components/schemas/BiolinkEntity'
           minItems: 1
-          nullable: false
         attributes:
           type: array
           description: A list of attributes describing the node
@@ -1262,7 +1234,6 @@ components:
           description: >-
             Value of the attribute. May be any data type, including a list.
           example: 0.000153
-          nullable: false
         value_type_id:
           oneOf:
             - $ref: '#/components/schemas/CURIE'
@@ -1328,7 +1299,6 @@ components:
           example: biolink:gene_associated_with_condition
           oneOf:
             - $ref: '#/components/schemas/BiolinkPredicate'
-          nullable: false
         subject:
           description: >-
             Corresponds to the map key CURIE of the
@@ -1336,7 +1306,6 @@ components:
           example: MONDO:0011382
           oneOf:
             - $ref: '#/components/schemas/CURIE'
-          nullable: false
         object:
           description: >-
             Corresponds to the map key CURIE of the
@@ -1344,7 +1313,6 @@ components:
           example: UniProtKB:P00738
           oneOf:
             - $ref: '#/components/schemas/CURIE'
-          nullable: false
         attributes:
           description: A list of additional attributes for this edge
           items:
@@ -1371,7 +1339,6 @@ components:
           items:
             $ref: '#/components/schemas/RetrievalSource'
           minItems: 1
-          nullable: false
       additionalProperties: false
       required:
         - object
@@ -1399,7 +1366,6 @@ components:
             which have slot names with the suffix string 'qualifier'.
           pattern: ^biolink:[a-z][a-z_]*$
           example: biolink:subject_aspect_qualifier
-          nullable: false
         qualifier_value:
           type: string
           description: >-
@@ -1411,7 +1377,6 @@ components:
             type is generally going to be constrained by the category
             of edge (i.e. biolink:Association subtype) of the (Q)Edge.
           example: expression
-          nullable: false
       required:
         - qualifier_type_id
         - qualifier_value
@@ -1435,7 +1400,6 @@ components:
           items:
             $ref: '#/components/schemas/Qualifier'
           minItems: 1
-          nullable: false
       required:
         - qualifier_set
       type: object
@@ -1489,7 +1453,6 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/MetaNode'
           minProperties: 1
-          nullable: false
         edges:
           type: array
           description: >-
@@ -1499,7 +1462,6 @@ components:
           items:
             $ref: '#/components/schemas/MetaEdge'
           minItems: 1
-          nullable: false
       required:
         - nodes
         - edges
@@ -1516,7 +1478,6 @@ components:
           items:
             type: string
           minItems: 1
-          nullable: false
           example: [CHEMBL.COMPOUND, INCHIKEY]
         attributes:
           type: array
@@ -1602,7 +1563,6 @@ components:
           description: >-
             The CURIE of the qualifier type.
           example: biolink:subject_aspect_qualifier
-          nullable: false
         applicable_values:
           type: array
           description: >-
@@ -1677,7 +1637,6 @@ components:
             as the 'id'. This is redundant but required for human
             readability.
           example: molecular mass
-          nullable: false
         not:
           type: boolean
           default: false
@@ -1715,7 +1674,6 @@ components:
             - ===
         value:
           example: 57.0
-          nullable: false
           description: >-
             Value of the attribute. May be any data type, including a list.
             If the value is a list and there are multiple items, at least one
@@ -1764,7 +1722,6 @@ components:
             of knowledge expressed in an Edge, or a source of data used to
             generate this knowledge.
           example: infores:drugbank
-          nullable: false
         resource_role:
           $ref: '#/components/schemas/ResourceRoleEnum'
           description: >-

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -278,6 +278,7 @@ components:
           description: The least critical level of logs to return
           oneOf:
             - $ref: '#/components/schemas/LogLevel'
+          type: string
           nullable: true
         workflow:
           description: List of workflow steps to be executed.
@@ -294,6 +295,7 @@ components:
         bypass_cache:
           type: boolean
           default: false
+          nullable: true
           description: >-
             Set to true in order to request that the agent obtain
             fresh information from its sources in all cases where
@@ -355,6 +357,7 @@ components:
         bypass_cache:
           type: boolean
           default: false
+          nullable: true
           description: >-
             Set to true in order to request that the agent obtain
             fresh information from its sources in all cases where
@@ -478,8 +481,8 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/LogEntry'
-          minItems: 0
-          nullable: false
+          minItems: 1
+          nullable: true
         workflow:
           description: List of workflow steps that were executed.
           oneOf:
@@ -523,7 +526,7 @@ components:
           items:
             $ref: '#/components/schemas/Result'
           nullable: true
-          minItems: 0
+          minItems: 1
         query_graph:
           description: >-
             QueryGraph object that contains a serialization of a query in the
@@ -531,6 +534,7 @@ components:
           oneOf:
             - $ref: '#/components/schemas/QueryGraph'
             - $ref: '#/components/schemas/PathfinderQueryGraph'
+          type: object
           nullable: true
         knowledge_graph:
           description: >-
@@ -538,6 +542,7 @@ components:
             in the thought graph corresponding to the message
           oneOf:
             - $ref: '#/components/schemas/KnowledgeGraph'
+          type: object
           nullable: true
         auxiliary_graphs:
           type: object
@@ -577,6 +582,7 @@ components:
         level:
           oneOf:
             - $ref: '#/components/schemas/LogLevel'
+          type: string
           nullable: true
         code:
           type: string
@@ -668,6 +674,7 @@ components:
             the NodeBinding.id being a descendant of a QNode.id), then
             this query_id MUST be provided. In other cases, there is no
             ambiguity, and this query_id SHOULD NOT be provided.
+          type: string
           nullable: true
         attributes:
           type: array
@@ -714,6 +721,7 @@ components:
             reasoning service. Each item in the list is the key of a
             single Auxiliary Graph.
           nullable: true
+          minItems: 1
           items:
             type: string
         scoring_method:
@@ -729,6 +737,7 @@ components:
           items:
             $ref: '#/components/schemas/Attribute'
           nullable: true
+          minItems: 1
       additionalProperties: true
       required:
         - resource_id
@@ -1014,6 +1023,7 @@ components:
             itself. This field MUST NOT be used under a set_interpretation 
             of BATCH.
           nullable: true
+          minItems: 1
           items:
             $ref: '#/components/schemas/CURIE'
         constraints:
@@ -1024,7 +1034,8 @@ components:
             to AND)
           items:
             $ref: '#/components/schemas/AttributeConstraint'
-          default: []
+          minItems: 1
+          nullable: true
       additionalProperties: true
     QEdge:
       type: object
@@ -1085,7 +1096,8 @@ components:
             to AND)
           items:
             $ref: '#/components/schemas/AttributeConstraint'
-          default: []
+          minItems: 1
+          nullable: true
         qualifier_constraints:
           type: array
           description: >-
@@ -1098,7 +1110,8 @@ components:
             because these complex use cases are not supported at this time.
           items:
             $ref: '#/components/schemas/QualifierConstraint'
-          default: []
+          minItems: 1
+          nullable: true
       additionalProperties: true
       required:
         - subject
@@ -1260,6 +1273,7 @@ components:
             descriptive phrase here and submit the new type for consideration
             by the appropriate authority.
           example: EDAM:data_1187
+          type: string
           nullable: true
         attribute_source:
           type: string
@@ -1292,6 +1306,7 @@ components:
           items:
             $ref: '#/components/schemas/Attribute'
           nullable: true
+          minItems: 1
       required:
         - attribute_type_id
         - value
@@ -1336,12 +1351,14 @@ components:
             $ref: '#/components/schemas/Attribute'
           nullable: true
           type: array
+          minItems: 1
         qualifiers:
           description: >-
             A set of Qualifiers that act together to add nuance
             or detail to the statement expressed in an Edge.
           items:
             $ref: '#/components/schemas/Qualifier'
+          minItems: 1
           nullable: true
           type: array
         sources:
@@ -1508,6 +1525,7 @@ components:
           items:
             $ref: '#/components/schemas/MetaAttribute'
           nullable: true
+          minItems: 1
       required:
         - id_prefixes
       additionalProperties: false
@@ -1549,11 +1567,13 @@ components:
           items:
             $ref: '#/components/schemas/MetaAttribute'
           nullable: true
+          minItems: 1
         qualifiers:
           description: >-
             Qualifiers that are possible to be found on this edge type.
           items:
             $ref: '#/components/schemas/MetaQualifier'
+          minItems: 1
           nullable: true
           type: array
         association:
@@ -1587,6 +1607,8 @@ components:
           type: array
           description: >-
                 The list of values that are possible for this qualifier.
+          nullable: true
+          minItems: 1
           items:
             type: string
             example: [expression, activity, abundance, degradation]
@@ -1621,6 +1643,7 @@ components:
             Indicates whether this attribute can be used as a query
             constraint.
           default: false
+          nullable: true
         constraint_name:
           type: string
           description: >-
@@ -1658,6 +1681,7 @@ components:
         not:
           type: boolean
           default: false
+          nullable: true
         operator:
           type: string
           description: >-
@@ -1708,6 +1732,7 @@ components:
             property. The Units of Measurement Ontology (UO) should be used
             if possible. The unit_id MUST be provided for (lists of)
             numerical values that correspond to a quantity that has units.
+          type: string
           nullable: true
         unit_name:
           example: kilodalton
@@ -1717,6 +1742,7 @@ components:
             property. The Units of Measurement Ontology (UO) SHOULD be used
             if possible. This property SHOULD be provided if a unit_id is
             provided. This is redundant but recommended for human readability.
+          type: string
           nullable: true
       required:
         - name
@@ -1749,6 +1775,7 @@ components:
         upstream_resource_ids:
           type: array
           nullable: true
+          minItems: 1
           items:
             $ref: '#/components/schemas/CURIE'
           description: >-
@@ -1764,6 +1791,7 @@ components:
         source_record_urls:
           type: array
           nullable: true
+          minItems: 1
           items: 
             type: string
           description: >-

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -1175,8 +1175,8 @@ components:
           description: A list of attributes describing the node
           items:
             $ref: '#/components/schemas/Attribute'
-          minItems: 0
-          nullable: false
+          minItems: 1
+          nullable: true
         is_set:
           type: boolean
           description: >-
@@ -1186,7 +1186,6 @@ components:
           nullable: true        
       required:
         - categories
-        - attributes
       additionalProperties: false
     Attribute:
       type: object

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -548,6 +548,7 @@ components:
           additionalProperties:
             $ref: '#/components/schemas/AuxiliaryGraph'
           nullable: true
+      minProperties: 1
       additionalProperties: false
     LogEntry:
       description: >-
@@ -621,6 +622,7 @@ components:
             items:
               $ref: '#/components/schemas/NodeBinding'
             minItems: 1
+          minProperties: 1
           nullable: false 
         analyses:
           type: array
@@ -631,7 +633,7 @@ components:
             oneOf:
               - $ref: '#/components/schemas/Analysis'
               - $ref: '#/components/schemas/PathfinderAnalysis'
-          minItems: 0
+          minItems: 1
           nullable: false 
       additionalProperties: true
       required:
@@ -753,6 +755,9 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/EdgeBinding'
+                minItems: 1
+              minProperties: 1
+              nullable: false
     PathfinderAnalysis:
       allOf: 
         - $ref: '#/components/schemas/BaseAnalysis'
@@ -771,6 +776,9 @@ components:
                 type: array
                 items:
                   $ref: '#/components/schemas/PathBinding'
+                minItems: 1
+              minProperties: 1
+              nullable: false
     EdgeBinding:
       type: object
       description: >-
@@ -866,6 +874,8 @@ components:
             referenced elsewhere in the TRAPI output by the dictionary key.
           additionalProperties:
             $ref: '#/components/schemas/Node'
+          minProperties: 1
+          nullable: false
         edges:
           type: object
           description: >-
@@ -873,6 +883,8 @@ components:
             referenced elsewhere in the TRAPI output by the dictionary key.
           additionalProperties:
             $ref: '#/components/schemas/Edge'
+          minProperties: 1
+          nullable: false
       additionalProperties: true
       required:
         - nodes
@@ -892,6 +904,8 @@ components:
             on bound nodes.
           additionalProperties:
             $ref: '#/components/schemas/QNode'
+          minProperties: 1
+          nullable: false
       additionalProperties: true
       required:
         - nodes
@@ -914,6 +928,8 @@ components:
                 QNodes.
               additionalProperties:
                 $ref: '#/components/schemas/QEdge'
+              minProperties: 1
+              nullable: false
     PathfinderQueryGraph:
       allOf: 
         - $ref: '#/components/schemas/BaseQueryGraph'
@@ -935,6 +951,7 @@ components:
                 $ref: '#/components/schemas/QPath'
               minProperties: 1
               maxProperties: 1
+              nullable: false
     QNode:
       type: object
       description: A node in the QueryGraph used to represent an entity in a
@@ -1050,6 +1067,7 @@ components:
             Corresponds to the map key identifier of the
             subject concept node anchoring the query filter
             pattern for the query relationship edge.
+          nullable: false
         object:
           type: string
           example: https://www.uniprot.org/uniprot/P00738
@@ -1057,6 +1075,7 @@ components:
             Corresponds to the map key identifier of the
             object concept node anchoring the query filter
             pattern for the query relationship edge.
+          nullable: false
         attribute_constraints:
           type: array
           description: >-
@@ -1097,12 +1116,14 @@ components:
             Corresponds to the map key identifier of the subject concept node for
             the start of the queried path.
           example: n0
+          nullable: false
         object:
           type: string
           description: >-
             Corresponds to the map key identifier of the object concept node for
             the end of the queried path.
           example: n1
+          nullable: false
         predicates:
           type: array
           description: >-
@@ -1394,6 +1415,7 @@ components:
             on queried Edges.
           items:
             $ref: '#/components/schemas/Qualifier'
+          minItems: 1
           nullable: false
       required:
         - qualifier_set
@@ -1447,6 +1469,8 @@ components:
             node for which that is the most specific category available.
           additionalProperties:
             $ref: '#/components/schemas/MetaNode'
+          minProperties: 1
+          nullable: false
         edges:
           type: array
           description: >-
@@ -1455,6 +1479,8 @@ components:
             for which the predicate is the most specific available.
           items:
             $ref: '#/components/schemas/MetaEdge'
+          minItems: 1
+          nullable: false
       required:
         - nodes
         - edges
@@ -1471,6 +1497,7 @@ components:
           items:
             type: string
           minItems: 1
+          nullable: false
           example: [CHEMBL.COMPOUND, INCHIKEY]
         attributes:
           type: array

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -819,6 +819,7 @@ components:
         id:
           type: string
           description: The key identifier of a specific auxiliary graph.
+          nullable: false
       additionalProperties: true
       required:
         - id
@@ -1248,6 +1249,7 @@ components:
           description: >-
             Value of the attribute. May be any data type, including a list.
           example: 0.000153
+          nullable: false
         value_type_id:
           oneOf:
             - $ref: '#/components/schemas/CURIE'
@@ -1652,6 +1654,7 @@ components:
             as the 'id'. This is redundant but required for human
             readability.
           example: molecular mass
+          nullable: false
         not:
           type: boolean
           default: false
@@ -1688,6 +1691,7 @@ components:
             - ===
         value:
           example: 57.0
+          nullable: false
           description: >-
             Value of the attribute. May be any data type, including a list.
             If the value is a list and there are multiple items, at least one


### PR DESCRIPTION
What this PR does:
* https://github.com/NCATSTranslator/ReasonerAPI/commit/432252d0a8ed4742ad7729ba224ea9f00d8d969f Make NodeBinding, EdgeBinding, AuxGraph `attributes` not required and not empty lists ▶️ Part of reducing bloat in TRAPI responses (addressing [513](https://github.com/NCATSTranslator/ReasonerAPI/issues/513))
   * More info in https://github.com/NCATSTranslator/ReasonerAPI/issues/506
* Make Node `attributes` not required/not empty lists ▶️ Part of reducing bloat in TRAPI responses (addressing [513](https://github.com/NCATSTranslator/ReasonerAPI/issues/513))
* attempt to make required/non-required property handling consistent, to address #514. I followed the plan described in the opening post of the issue as much as I could, but I was confused by `$ref` and `oneOf` inheritance situations. 
* **made a commit removing `nullable: false`, so people can review and test having this nullable setting or not (by reverting this commit locally or not).** See the discussion in issue 514 on whether explicitly writing `nullable: false` has any effect or is helpful.