### PR TITLE
Make attributes not required

### DIFF
--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -681,7 +681,6 @@ components:
       additionalProperties: true
       required:
         - id
-        - attributes
     BaseAnalysis:
       type: object
       description: >-
@@ -801,7 +800,6 @@ components:
       additionalProperties: true
       required:
         - id
-        - attributes
     PathBinding:
       type: object
       description: >-
@@ -851,7 +849,6 @@ components:
       additionalProperties: true
       required:
         - edges
-        - attributes
     KnowledgeGraph:
       type: object
       description: >-
@@ -1189,7 +1186,6 @@ components:
           nullable: true        
       required:
         - categories
-        - attributes
       additionalProperties: false
     Attribute:
       type: object

--- a/TranslatorReasonerAPI.yaml
+++ b/TranslatorReasonerAPI.yaml
@@ -677,7 +677,7 @@ components:
           items:
             $ref: '#/components/schemas/Attribute'
           minItems: 0
-          nullable: false
+          nullable: true
       additionalProperties: true
       required:
         - id
@@ -796,7 +796,7 @@ components:
           items:
             $ref: '#/components/schemas/Attribute'
           minItems: 0
-          nullable: false
+          nullable: true
       additionalProperties: true
       required:
         - id
@@ -845,7 +845,7 @@ components:
           items:
             $ref: '#/components/schemas/Attribute'
           minItems: 0
-          nullable: false
+          nullable: true
       additionalProperties: true
       required:
         - edges
@@ -1176,7 +1176,7 @@ components:
           items:
             $ref: '#/components/schemas/Attribute'
           minItems: 0
-          nullable: false
+          nullable: true
         is_set:
           type: boolean
           description: >-


### PR DESCRIPTION
[One way to address #506]

Keeping as draft since some decisions haven't been reached yet. 

Currently:
* leaving `minItems: 0` since that's the unofficial consensus during today's TRAPI meeting
* setting `nullable: true` since that's the current consensus reached 9/25
   * means the value can be an array (with its constraints) or `null`
   * this is straightforward and should work (no sibling `$ref`, "Of" statements)